### PR TITLE
Установка значений полей формы в окне

### DIFF
--- a/assets/components/minishop2/js/mgr/orders/orders.grid.js
+++ b/assets/components/minishop2/js/mgr/orders/orders.grid.js
@@ -217,8 +217,8 @@ Ext.extend(miniShop2.grid.Orders,MODx.grid.Grid,{
 								}}
 							}
 						});
-					w.fp.getForm().reset();
-					w.fp.getForm().setValues(r.object);
+					w.reset();
+					w.setValues(r.object);
 					w.show(e.target,function() {w.setPosition(null,100)},this);
 					/* Need to refresh grids with goods and logs */
 				},scope:this}
@@ -619,8 +619,8 @@ Ext.extend(miniShop2.grid.Products,MODx.grid.Grid, {
 							 ,hide: {fn: function() {this.getEl().remove();}}
 						 }
 					 });
-					 w.fp.getForm().reset();
-					 w.fp.getForm().setValues(r.object);
+					 w.reset();
+					 w.setValues(r.object);
 					 w.show(e.target,function() {w.setPosition(null,100)},this);
 				},scope:this}
 			}
@@ -656,8 +656,8 @@ Ext.extend(miniShop2.grid.Products,MODx.grid.Grid, {
 							,hide: {fn: function() {this.getEl().remove();}}
 						}
 					});
-					w.fp.getForm().reset();
-					w.fp.getForm().setValues(r.object);
+					w.reset();
+					w.setValues(r.object);
 					w.show(e.target,function() {w.setPosition(null,100)},this);
 				},scope:this}
 			}

--- a/assets/components/minishop2/js/mgr/settings/delivery.grid.js
+++ b/assets/components/minishop2/js/mgr/settings/delivery.grid.js
@@ -108,7 +108,8 @@ Ext.extend(miniShop2.grid.Delivery,MODx.grid.Grid,{
 				}
 			});
 		//}
-		this.windows.createDelivery.fp.getForm().reset().setValues({
+		this.windows.createDelivery.reset();
+		this.windows.createDelivery.setValues({
 			price: 0
 			,weight_price: 0
 			,distance_price: 0
@@ -133,8 +134,8 @@ Ext.extend(miniShop2.grid.Delivery,MODx.grid.Grid,{
 				}
 			});
 		//}
-		this.windows.updateDelivery.fp.getForm().reset();
-		this.windows.updateDelivery.fp.getForm().setValues(r);
+		this.windows.updateDelivery.reset();
+		this.windows.updateDelivery.setValues(r);
 		this.windows.updateDelivery.show(e.target);
 		this.enablePayments(r.payments);
 	}

--- a/assets/components/minishop2/js/mgr/settings/link.grid.js
+++ b/assets/components/minishop2/js/mgr/settings/link.grid.js
@@ -74,7 +74,7 @@ Ext.extend(miniShop2.grid.Link,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.createLink.fp.getForm().reset();
+		this.windows.createLink.reset();
 		this.windows.createLink.show(e.target);
 		Ext.getCmp('minishop2-link-type_desc-create').getEl().dom.innerText = '';
 	}
@@ -93,8 +93,8 @@ Ext.extend(miniShop2.grid.Link,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.updateLink.fp.getForm().reset();
-		this.windows.updateLink.fp.getForm().setValues(r);
+		this.windows.updateLink.reset();
+		this.windows.updateLink.setValues(r);
 		this.windows.updateLink.show(e.target);
 		Ext.getCmp('minishop2-link-type_desc-update').getEl().dom.innerText = r.type ? _('ms2_link_'+r.type+'_desc') : '';
 	}

--- a/assets/components/minishop2/js/mgr/settings/payment.grid.js
+++ b/assets/components/minishop2/js/mgr/settings/payment.grid.js
@@ -112,7 +112,7 @@ Ext.extend(miniShop2.grid.Payment,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.createPayment.fp.getForm().reset();
+		this.windows.createPayment.reset();
 		this.windows.createPayment.show(e.target);
 	}
 	,updatePayment: function(btn,e) {
@@ -129,8 +129,8 @@ Ext.extend(miniShop2.grid.Payment,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.updatePayment.fp.getForm().reset();
-		this.windows.updatePayment.fp.getForm().setValues(r);
+		this.windows.updatePayment.reset();
+		this.windows.updatePayment.setValues(r);
 		this.windows.updatePayment.show(e.target);
 	}
 

--- a/assets/components/minishop2/js/mgr/settings/status.grid.js
+++ b/assets/components/minishop2/js/mgr/settings/status.grid.js
@@ -105,8 +105,8 @@ Ext.extend(miniShop2.grid.Status,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.createStatus.fp.getForm().reset();
-		this.windows.createStatus.fp.getForm().setValues({color:'000000'});
+		this.windows.createStatus.reset();
+		this.windows.createStatus.setValues({color:'000000'});
 		this.windows.createStatus.show(e.target);
 	}
 
@@ -124,9 +124,9 @@ Ext.extend(miniShop2.grid.Status,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.updateStatus.fp.getForm().reset();
+		this.windows.updateStatus.reset();
 		this.windows.updateStatus.show(e.target);
-		this.windows.updateStatus.fp.getForm().setValues(r);
+		this.windows.updateStatus.setValues(r);
 	}
 
 	,removeStatus: function(btn,e) {

--- a/assets/components/minishop2/js/mgr/settings/vendor.grid.js
+++ b/assets/components/minishop2/js/mgr/settings/vendor.grid.js
@@ -76,7 +76,7 @@ Ext.extend(miniShop2.grid.Vendor,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.createVendor.fp.getForm().reset();
+		this.windows.createVendor.reset();
 		this.windows.createVendor.show(e.target);
 	}
 
@@ -94,8 +94,8 @@ Ext.extend(miniShop2.grid.Vendor,MODx.grid.Grid,{
 				}
 			});
 		}
-		this.windows.updateVendor.fp.getForm().reset();
-		this.windows.updateVendor.fp.getForm().setValues(r);
+		this.windows.updateVendor.reset();
+		this.windows.updateVendor.setValues(r);
 		this.windows.updateVendor.show(e.target);
 	}
 


### PR DESCRIPTION
У всех наследников `MODx.Window` есть методы `setValues` и `reset`. Лучше вызывать их, это дает возможность переопределить эти методы и вклиниться в процесс установки значений. Метод `reset` думаю не так важен для переопределения, но для симметрии лучше и его вызывать не напрямую у формы.
