### PR TITLE
Order : Add delivery [[+cost]] placeholder

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_order.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_order.php
@@ -83,6 +83,8 @@ if (!empty($deliveries)) {
 		$pdoFetch->addTime('Processing delivery '.$delivery['name'].'.');
 		$delivery['checked'] = !empty($order['delivery']) && $order['delivery'] == $did ? 'checked' : '';
 		$delivery['payments'] = $modx->toJSON($delivery['payments']);
+                $deliveryObj = $miniShop2->modx->getObject('msDelivery', $did);
+                $delivery['cost'] = $deliveryObj->getCost($miniShop2->order, 0);
 		$arrays['deliveries'][$did] = empty($tplDelivery)
 			? $pdoFetch->getChunk('', $delivery)
 			: $pdoFetch->getChunk($tplDelivery, $delivery);


### PR DESCRIPTION
Hi :) I added theses 2 lines so I can use [[+cost]] placeholder in the tpl.msOrder.delivery chunk. This way, I could display the cost of each delivery option. 

(could not find any other way to acheive this, hope I did well) (I think you'll have a better idea for the variable name $deliveryObj :)

++
