### PR TITLE
Added support for ContentBlocks

### DIFF
--- a/assets/components/minishop2/js/mgr/category/category.common.js
+++ b/assets/components/minishop2/js/mgr/category/category.common.js
@@ -41,6 +41,7 @@ Ext.extend(miniShop2.panel.CategoryTemplateSettings,MODx.Panel,{
 			,height: 300
 			,grow: false
 			,value: config.record.content
+			,itemCls: 'contentblocks_replacement'
 		},{
 			id: 'modx-content-below'
 			,border: false

--- a/assets/components/minishop2/js/mgr/product/product.common.js
+++ b/assets/components/minishop2/js/mgr/product/product.common.js
@@ -238,7 +238,7 @@ var methods = {
 			,longtitle: {xtype: 'textfield'}
 			,description: {xtype: 'textarea'}
 			,introtext: {xtype: 'textarea', description: '<b>[[*introtext]]</b><br />'+_('resource_summary_help')}
-			,content: {xtype: 'textarea',name: 'ta',id: 'ta',description:'', height: 400,grow: false,value: (config.record.content || config.record.ta) || ''}
+			,content: {xtype: 'textarea',name: 'ta',id: 'ta',description:'', height: 400,grow: false,value: (config.record.content || config.record.ta) || '',itemCls: 'contentblocks_replacement'}
 
 			,createdby: {xtype: 'minishop2-combo-user',value: config.record.createdby, description: '<b>[[*createdby]]</b><br/>' + _('ms2_product_createdby_help')}
 			,publishedby: {xtype: 'minishop2-combo-user',value: config.record.publishedby, description: '<b>[[*publishedby]]</b><br/>' + _('ms2_product_publishedby_help')}


### PR DESCRIPTION
added `,itemCls: 'contentblocks_replacement'` to the definition of the `contentField` for msProduct and msCategory. This enables ContentBlocks support for minishop2. This change doesn't have any effects as long as someone does not have [ContentBlocks](https://www.modmore.com/extras/contentblocks/) installed and added `msProduct` and `msCategory` to `contentblocks.accepted_resource_types`. But if this is the case, minishop2 will now show ContentBlocks.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bezumkin/minishop2/160)

<!-- Reviewable:end -->
