### PR TITLE
Изменение любых полей продукта по событию msOnGetProductFields

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -108,12 +108,6 @@ if (!empty($rows) && is_array($rows)) {
 		if ($modificators) {
 			$product->fromArray($row, '', true, true);
 			$row = $product->prepareFields($row);
-			/*$tmp = $row['price'];
-			$row['price'] = $product->getPrice($row);
-			$row['weight'] = $product->getWeight($row);
-			if ($row['price'] != $tmp) {
-				$row['old_price'] = $tmp;
-			}*/
 		}
 		$row['price'] = $miniShop2->formatPrice($row['price']);
 		$row['old_price'] = $miniShop2->formatPrice($row['old_price']);

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -94,7 +94,7 @@ if (!empty($returnIds)) {return $rows;}
 // Processing rows
 $output = array();
 if (!empty($rows) && is_array($rows)) {
-	$q = $modx->newQuery('modPluginEvent', array('event:IN' => array('msOnGetProductPrice','msOnGetProductWeight')));
+	$q = $modx->newQuery('modPluginEvent', array('event:IN' => array('msOnGetProductPrice','msOnGetProductWeight', 'msOnGetProductFields')));
 	$q->innerJoin('modPlugin', 'modPlugin', 'modPlugin.id = modPluginEvent.pluginid');
 	$q->where('modPlugin.disabled = 0');
 

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -107,12 +107,13 @@ if (!empty($rows) && is_array($rows)) {
 	foreach ($rows as $k => $row) {
 		if ($modificators) {
 			$product->fromArray($row, '', true, true);
-			$tmp = $row['price'];
+			$row = $product->prepareFields($row);
+			/*$tmp = $row['price'];
 			$row['price'] = $product->getPrice($row);
 			$row['weight'] = $product->getWeight($row);
 			if ($row['price'] != $tmp) {
 				$row['old_price'] = $tmp;
-			}
+			}*/
 		}
 		$row['price'] = $miniShop2->formatPrice($row['price']);
 		$row['old_price'] = $miniShop2->formatPrice($row['old_price']);

--- a/core/components/minishop2/model/minishop2/msproduct.class.php
+++ b/core/components/minishop2/model/minishop2/msproduct.class.php
@@ -511,4 +511,8 @@ class msProduct extends modResource {
 	public function getWeight($data = array()) {
 		return $this->loadData()->getWeight($data);
 	}
+	
+	public function prepareFields($data = array()) {
+		return $this->loadData()->prepareFields($data);
+	}
 }

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -255,5 +255,29 @@ class msProductData extends xPDOSimpleObject {
 	}
 
 
+	/* Returns prepared product fields.
+	 *
+	 * @return array $result Prepared fields of product.
+	 * */
+	public function prepareFields() {
+
+		$data = $this->toArray();
+		/** @var miniShop2 $miniShop2 */
+		$miniShop2 = $this->xpdo->getService('minishop2');
+		$params = array(
+			'product' => $this,
+			'data' => $data,
+		);
+		$response = $miniShop2->invokeEvent('msOnGetProductFields', $params);
+		if ($response['success']) {
+		    unset($response['data']['product']);
+		    $result = array_merge($data, $response['data']);
+		} else {
+		    $result = $data;
+		}
+
+		return $result;
+	}
+
 
 }


### PR DESCRIPTION
Собственно возникла необходимость менять в событии msOnGetProductFields значения не только цены, но и старой цены. Но изменение старой цены прибито гвоздями в коде, поэтому пришлось добавить еще один метод к продукту - prepareFields. Он полностью заменяет методы getPrice и getWeight, хотя их в коде лучше оставить в целях обратной совместимости.
