### PR TITLE
Different product ordering for each category

### DIFF
--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -65,7 +65,9 @@ if ($object->xpdo) {
 				));
 			}
 
-			$modx->setLogLevel($level);
+		$manager->addField('msCategoryMember', 'rank', array('after' => 'category_id'));
+
+		$modx->setLogLevel($level);
 
 			break;
 

--- a/assets/components/minishop2/js/mgr/category/category.grid.js
+++ b/assets/components/minishop2/js/mgr/category/category.grid.js
@@ -102,7 +102,7 @@ Ext.extend(miniShop2.grid.Category,MODx.grid.Grid,{
 							action: 'mgr/product/sort'
 							,source: source.id
 							,target: target.id
-							,parent: source.parent
+							,parent: MODx.request.id // this should be page ID
 						}
 						,listeners: {
 							success: {fn:function(r) {dd.el.unmask();grid.refresh();},scope:grid}

--- a/assets/components/minishop2/js/mgr/category/category.grid.js
+++ b/assets/components/minishop2/js/mgr/category/category.grid.js
@@ -101,6 +101,7 @@ Ext.extend(miniShop2.grid.Category,MODx.grid.Grid,{
 							action: 'mgr/product/sort'
 							,source: source.id
 							,target: target.id
+							,parent: source.parent
 						}
 						,listeners: {
 							success: {fn:function(r) {dd.el.unmask();grid.refresh();},scope:grid}

--- a/assets/components/minishop2/js/mgr/category/category.grid.js
+++ b/assets/components/minishop2/js/mgr/category/category.grid.js
@@ -4,6 +4,7 @@ miniShop2.grid.Category = function(config) {
 	var baseParams = {
 		action: 'mgr/product/getlist'
 		,parent: config.resource
+		,sort: 'rank'
 	};
 	var params = {};
 	if (MODx.config.ms2_category_remember_grid) {

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -22,9 +22,7 @@ if (empty($showZeroPrice)) {$where['Data.price:>'] = 0;}
 $leftJoin = array(
 	array('class' => 'msProductData', 'alias' => 'Data', 'on' => '`'.$class.'`.`id`=`Data`.`id`'),
 	array('class' => 'msVendor', 'alias' => 'Vendor', 'on' => '`Data`.`vendor`=`Vendor`.`id`'),
-);
-$innerJoin = array(
-	array('class' => 'msCategoryMember', 'alias' => 'catMember', 'on' => '`catMember`.`product_id` = `msProduct`.`id`')
+	array('class' => 'msCategoryMember', 'alias' => 'catMember', 'on' => '`catMember`.`product_id` = `msProduct`.`id`'),
 );
 
 // Include Thumbnails

--- a/core/components/minishop2/model/minishop2/mscategorymember.class.php
+++ b/core/components/minishop2/model/minishop2/mscategorymember.class.php
@@ -1,2 +1,25 @@
 <?php
-class msCategoryMember extends xPDOObject {}
+class msCategoryMember extends xPDOObject {
+
+	public function save($cacheFlag) {
+		$res = parent::save($cacheFlag);
+		if($this->get('rank') == 0) {
+			$max = 0;
+			$q = $this->xpdo->newQuery('msCategoryMember');
+			$q->where(array('category_id' => $this->get('category_id')));
+			$q->sortby('rank', 'DESC');
+			$q->limit(1);
+			$maxObj = $this->xpdo->getObject('msCategoryMember', $q);
+			if($maxObj) {
+				$max = $maxObj->get('rank') + 1;
+			}
+
+			$q = "UPDATE {$this->xpdo->getTableName('msCategoryMember')}
+				SET rank = {$max} WHERE
+					product_id = {$this->get('product_id')}
+					AND category_id = {$this->get('category_id')}";
+			$this->xpdo->exec($q);
+		}
+		return $res;
+	}
+}

--- a/core/components/minishop2/model/minishop2/mysql/mscategorymember.map.inc.php
+++ b/core/components/minishop2/model/minishop2/mysql/mscategorymember.map.inc.php
@@ -8,6 +8,7 @@ $xpdo_meta_map['msCategoryMember']= array (
   array (
     'product_id' => NULL,
     'category_id' => NULL,
+    'rank' => NULL,
   ),
   'fieldMeta' => 
   array (
@@ -21,6 +22,15 @@ $xpdo_meta_map['msCategoryMember']= array (
       'index' => 'pk',
     ),
     'category_id' => 
+    array (
+      'dbtype' => 'int',
+      'precision' => '10',
+      'attributes' => 'unsigned',
+      'phptype' => 'integer',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'rank' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',

--- a/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
+++ b/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
@@ -90,6 +90,7 @@
 	<object class="msCategoryMember" table="ms2_product_categories" extends="xPDOObject">
 		<field key="product_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" index="pk" />
 		<field key="category_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" index="pk" />
+		<field key="rank" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" index="pk" />
 
 		<index alias="product" name="product" primary="true" unique="true" type="BTREE" >
 			<column key="product_id" length="" collation="A" null="false" />

--- a/core/components/minishop2/processors/mgr/product/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/product/getlist.class.php
@@ -37,6 +37,7 @@ class msProductGetListProcessor extends modObjectGetListProcessor {
 			$c->select($this->modx->getSelectColumns('msVendor','Vendor', 'vendor_', array('name')));
 			$c->select($this->modx->getSelectColumns('msCategory','Category', 'category_', array('pagetitle')));
 		}
+		$c->select('Member.rank');
 		if ($query = $this->getProperty('query',null)) {
 			$queryWhere = array(
 				'msProduct.id' => $query

--- a/core/components/minishop2/processors/mgr/product/sort.class.php
+++ b/core/components/minishop2/processors/mgr/product/sort.class.php
@@ -1,60 +1,65 @@
 <?php
 
 class msProductSortProcessor extends modObjectProcessor {
-	public $classKey = 'msProduct';
+	public $classKey = 'msCategoryMember';
 	private $parent;
 
 
 	/** {@inheritDoc} */
 	public function process() {
 		/* @var msProduct $source */
-		$source = $this->modx->getObject($this->classKey, $this->getProperty('source'));
+		$source = $this->modx->getObject($this->classKey, array(
+			'product_id' => $this->getProperty('source')
+			,'category_id' => $this->getProperty('parent')
+		));
 		/* @var msProduct $target */
-		$target = $this->modx->getObject($this->classKey, $this->getProperty('target'));
+		$target = $this->modx->getObject($this->classKey, array(
+			'product_id' => $this->getProperty('target')
+			,'category_id' => $this->getProperty('parent')
+		));
 
 		if (empty($source) || empty($target)) {
 			return $this->modx->error->failure();
 		}
-		$this->parent = $source->get('parent');
 
-		if ($source->get('menuindex') < $target->get('menuindex')) {
-			$this->modx->exec("UPDATE {$this->modx->getTableName($this->classKey)}
-				SET menuindex = menuindex - 1 WHERE
-					menuindex <= {$target->get('menuindex')}
-					AND menuindex > {$source->get('menuindex')}
-					AND menuindex > 0
-			");
+		// ignore whatever is below here and only use our new "rank"
 
-		} else {
-			$this->modx->exec("UPDATE {$this->modx->getTableName($this->classKey)}
-				SET menuindex = menuindex + 1 WHERE
-					menuindex >= {$target->get('menuindex')}
-					AND menuindex < {$source->get('menuindex')}
-			");
-		}
-		$newRank = $target->get('menuindex');
-		$source->set('menuindex',$newRank);
-		$source->save();
+		// get "source" msCategoryMember
+		// add 1 to all ranks AFTER AND INCLUDING that source
+		// update "target" with new msCategoryMember
+		// re-number to fill any gaps
+		$newRankForTarget = $target->get('rank');
 
-		if (!$this->modx->getCount($this->classKey, array('menuindex' => 0, 'parent' => $this->parent))) {
-			$this->setIndex();
-		}
+		$q = "UPDATE {$this->modx->getTableName($this->classKey)}
+				SET rank = rank + 1 WHERE
+					rank >= {$target->get('rank')}
+					AND category_id = {$this->getProperty('parent')}";
+		$this->modx->exec($q);
+
+		$q = "UPDATE {$this->modx->getTableName($this->classKey)}
+				SET rank = {$newRankForTarget} WHERE
+					product_id = {$this->getProperty('source')}
+					AND category_id = {$this->getProperty('parent')}";
+		$this->modx->exec($q);
+
+		$this->setIndex();
+
 		return $this->modx->error->success();
 	}
 
 
 	/** {@inheritDoc} */
 	public function setIndex() {
-		$q = $this->modx->newQuery($this->classKey, array('parent' => $this->parent));
-		$q->select('id');
-		$q->sortby('menuindex ASC, id', 'ASC');
+		$q = $this->modx->newQuery($this->classKey, array('category_id' => $this->getProperty('parent')));
+		$q->select('product_id');
+		$q->sortby('rank ASC, product_id', 'ASC');
 
 		if ($q->prepare() && $q->stmt->execute()) {
 			$ids = $q->stmt->fetchAll(PDO::FETCH_COLUMN);
 			$sql = '';
 			$table = $this->modx->getTableName($this->classKey);
 			foreach ($ids as $k => $id) {
-				$sql .= "UPDATE {$table} SET `menuindex` = '{$k}' WHERE `id` = '{$id}';";
+				$sql .= "UPDATE {$table} SET `rank` = '{$k}' WHERE `product_id` = '{$id}' AND category_id = '{$this->getProperty('parent')}';";
 			}
 			$this->modx->exec($sql);
 		}

--- a/core/components/minishop2/processors/mgr/product/sort.class.php
+++ b/core/components/minishop2/processors/mgr/product/sort.class.php
@@ -22,8 +22,6 @@ class msProductSortProcessor extends modObjectProcessor {
 			return $this->modx->error->failure();
 		}
 
-		// ignore whatever is below here and only use our new "rank"
-
 		// get "source" msCategoryMember
 		// add 1 to all ranks AFTER AND INCLUDING that source
 		// update "target" with new msCategoryMember

--- a/core/components/minishop2/processors/mgr/product/sort.class.php
+++ b/core/components/minishop2/processors/mgr/product/sort.class.php
@@ -58,8 +58,10 @@ class msProductSortProcessor extends modObjectProcessor {
 			$ids = $q->stmt->fetchAll(PDO::FETCH_COLUMN);
 			$sql = '';
 			$table = $this->modx->getTableName($this->classKey);
+			$r = 0;
 			foreach ($ids as $k => $id) {
-				$sql .= "UPDATE {$table} SET `rank` = '{$k}' WHERE `product_id` = '{$id}' AND category_id = '{$this->getProperty('parent')}';";
+				$r++;
+				$sql .= "UPDATE {$table} SET `rank` = '{$r}' WHERE `product_id` = '{$id}' AND category_id = '{$this->getProperty('parent')}';";
 			}
 			$this->modx->exec($sql);
 		}


### PR DESCRIPTION
### What does it do ?

Extending the "category member" functionality, this PR allows you to drag/drop the order of products within a category and change the order they display through the msProducts snippet. So a product can now appear in 2 categories in different positions on the front end.
### Why is it needed ?

At the moment all categories (if sorted by menuindex) do not allow the products to be in different orders. This is quite restrictive when a lot of products exist across multiple categories.
### What has been updated

The "category" page within the manager now allows you to drag and drop to change the order of items.

To set the msProducts snippet call to order by the new rank then use the new script property:

```
[[!pdoPage?
    &element=`msProducts`
    &sortby=`menuindex`
    &rankedCategory=`[[*id]]`
    &showLog=`1`
]]
```

`&rankedCategory` allows you to say which category to use as the parent (This property sets the `parents=0` so all resources are included.)

You can also set the rankedCategory as multiple categories or exclude some. E.g.

```
&rankedCategory=`2,5`
```

^ List multiple categories

```
&rankedCategory=`-10`
```

Exclude category 10
