### PR TITLE
Notice

### DIFF
--- a/core/components/minishop2/processors/mgr/product/create.class.php
+++ b/core/components/minishop2/processors/mgr/product/create.class.php
@@ -57,7 +57,9 @@ class msProductCreateProcessor extends modResourceCreateProcessor {
 		// Updating resourceMap before OnDocSaveForm event
 		$results = $this->modx->cacheManager->generateContext($this->object->context_key);
 		$this->modx->context->resourceMap = $results['resourceMap'];
-		$this->modx->context->aliasMap = $results['aliasMap'];
+		if(isset($results['aliasMap'])){
+			$this->modx->context->aliasMap = $results['aliasMap'];
+		}
 
 		return parent::afterSave();
 	}


### PR DESCRIPTION
$results['aliasMap'] может отсутствовать, если отключена системная настройка cache_alias_map
