### PR TITLE
Added new events for msOrderProduct processors

### DIFF
--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -31,6 +31,13 @@ $tmp = array(
 	'msOnCreateOrder',
 	'msOnBeforeRemoveOrder',
 	'msOnRemoveOrder',
+	
+	'msOnBeforeAddOrderProduct',
+	'msOnAddOrderProduct',
+	'msOnBeforeUpdateOrderProduct',
+	'msOnUpdateOrderProduct',
+	'msOnBeforeRemoveOrderProduct',
+	'msOnRemoveOrderProduct',
 
 	'msOnSubmitOrder',
 	'msOnManagerCustomCssJs',

--- a/core/components/minishop2/processors/mgr/orders/product/create.class.php
+++ b/core/components/minishop2/processors/mgr/orders/product/create.class.php
@@ -3,6 +3,8 @@
 class msOrderProductCreateProcessor extends modObjectCreateProcessor {
 	public $classKey = 'msOrderProduct';
 	public $languageTopics = array('minishop2:default');
+	public $beforeSaveEvent = 'msOnBeforeAddOrderProduct';
+	public $afterSaveEvent = 'msOnAddOrderProduct';
 	public $permission = 'msorder_save';
 	/* @var msOrder $order */
 	protected $order;

--- a/core/components/minishop2/processors/mgr/orders/product/remove.class.php
+++ b/core/components/minishop2/processors/mgr/orders/product/remove.class.php
@@ -3,6 +3,8 @@
 class msOrderProductRemoveProcessor extends modObjectRemoveProcessor  {
 	public $classKey = 'msOrderProduct';
 	public $languageTopics = array('minishop2:default');
+	public $beforeRemoveEvent = 'msOnBeforeRemoveOrderProduct';
+	public $afterRemoveEvent = 'msOnRemoveOrderProduct';
 	public $permission = 'msorder_save';
 	/* @var msOrder $order */
 	protected $order;

--- a/core/components/minishop2/processors/mgr/orders/product/update.class.php
+++ b/core/components/minishop2/processors/mgr/orders/product/update.class.php
@@ -3,6 +3,8 @@
 class msOrderProductUpdateProcessor extends modObjectUpdateProcessor {
 	public $classKey = 'msOrderProduct';
 	public $languageTopics = array('minishop2:default');
+	public $beforeSaveEvent = 'msOnBeforeUpdateOrderProduct';
+	public $afterSaveEvent = 'msOnUpdateOrderProduct';
 	public $permission = 'msorder_save';
 	/* @var msOrder $order */
 	protected $order;


### PR DESCRIPTION
Новые события для процессоров добавления/изменения/удаления товаров у уже оформленных заказов.
Для чего: очень необходимо для дальнейшего развития компонента учёта остатков, так как на текущий момент нет никакой возможности внедряться в вышеуказанные процессы. А это необходимо для того, чтобы можно было отследить какое изначально было количество товаров, и какое было добавлено/убрано.
