### PR TITLE
Added method getContent to Category

### DIFF
--- a/assets/components/minishop2/js/mgr/category/category.common.js
+++ b/assets/components/minishop2/js/mgr/category/category.common.js
@@ -59,9 +59,6 @@ Ext.extend(miniShop2.panel.Category, MODx.panel.Resource, {
                 item.hideLabel = false;
                 item.fieldLabel = _('content');
                 item.description = '<b>[[*content]]</b>';
-                if (MODx.config['ms2_category_content_default']) {
-                    item.value = MODx.config['ms2_category_content_default'];
-                }
             }
             fields.push(item);
         }

--- a/core/components/minishop2/model/minishop2/mscategory.class.php
+++ b/core/components/minishop2/model/minishop2/mscategory.class.php
@@ -172,4 +172,25 @@ class msCategory extends modResource
 
         return $arr;
     }
+
+
+    /**
+     * Gets the raw, unprocessed source content for a resource.
+     * Adding ms2_category_content_default processing
+     *
+     * @param array $options An array of options implementations can use to
+     * accept language, revision identifiers, or other information to alter the
+     * behavior of the method.
+     * @return string The raw source content for the resource.
+     */
+    public function getContent(array $options = array()) {
+        $content = '';
+        if (isset($options['content'])) {
+            $content = $options['content'];
+        } else {
+            $content = $this->get('content');
+        }
+        $content .= $this->xpdo->getOption('ms2_category_content_default', null, '');
+        return $content;
+    }
 }

--- a/core/components/minishop2/model/minishop2/mscategory.class.php
+++ b/core/components/minishop2/model/minishop2/mscategory.class.php
@@ -184,12 +184,7 @@ class msCategory extends modResource
      * @return string The raw source content for the resource.
      */
     public function getContent(array $options = array()) {
-        $content = '';
-        if (isset($options['content'])) {
-            $content = $options['content'];
-        } else {
-            $content = $this->get('content');
-        }
+        $content = parent::getContent($options);
         $content .= $this->xpdo->getOption('ms2_category_content_default', null, '');
         return $content;
     }


### PR DESCRIPTION
Есть предложение использовать настройку **ms2_category_content_default** не в файле **category.common.js**, а реализовать в файле **mscategory.class.php** метод **getContent**. Пусть код из настройки добавляется к полю **content** и выводится только на фронтенде.

Тогда изменение настройки повлияет сразу на все категории.
