### PR TITLE
Общая информация о количестве и сумме заказов

### DIFF
--- a/core/components/minishop2/processors/mgr/orders/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/orders/getlist.class.php
@@ -225,7 +225,7 @@ class msOrderGetListProcessor extends modObjectGetListProcessor
         $selected->query['columns'] = array();
         $selected->query['limit'] =
         $selected->query['offset'] = 0;
-        $selected->where(array('type' => 0));
+        $selected->where(array('type' => 0, 'status' => 2, 'status' => 3));
         $selected->select('SUM(msOrder.cost)');
         $selected->prepare();
         $selected->stmt->execute();
@@ -242,10 +242,10 @@ class msOrderGetListProcessor extends modObjectGetListProcessor
             'success' => true,
             'results' => $array,
             'total' => $count,
-            'num' => $this->ms2->formatPrice($count),
-            'sum' => $this->ms2->formatPrice($selected->stmt->fetchColumn()),
-            'month_sum' => $this->ms2->formatPrice($month['sum']),
-            'month_total' => $this->ms2->formatPrice($month['total']),
+            'num' => $count,
+            'sum' => round($selected->stmt->fetchColumn()).$this->modx->lexicon('ms2_frontend_currency'),
+            'month_sum' => round($month['sum']).$this->modx->lexicon('ms2_frontend_currency'),
+            'month_total' => $month['total'],
         );
 
         return json_encode($data);


### PR DESCRIPTION
1. Общую сумму заказов считаем только по отправленным и оплаченным заказам (нет смысла считать сумму вместе с не оплаченными заказами, так как в этой цифре нет абсолютно никакого смысла).
2. К количеству заказов применялся formatPrice. Но зачем? Исправил.
3. Общую сумму заказов думаю нет смысла считать с копейками, поэтому formatPrice тоже убрал. На проекте где продаж на сумму несколько сотен тысяч долларов, цифра разбивается на две строки (плюс дробная часть и пробелы-разделители разрядов), что не очень красиво. Как вариант можно оставить formatPrice, но сделать шрифт общей суммы меньше.
4. Добавил символ валюты к сумме, а то по началу не совсем понятно что это за цифра.
