### PR TITLE
Выставление ранга у превьюх

### DIFF
--- a/core/components/minishop2/processors/mgr/gallery/sort.class.php
+++ b/core/components/minishop2/processors/mgr/gallery/sort.class.php
@@ -58,6 +58,10 @@ class msProductFileSortProcessor extends modObjectProcessor
         }
         $source->set('rank', $newRank);
         $source->save();
+        
+        $this->modx->exec("UPDATE {$this->modx->getTableName('msProductFile')}
+            SET rank = " . $source->get('rank') . " WHERE
+        		parent = " . $source->get('id'));   
 
         $thumb = $product->updateProductImage();
 


### PR DESCRIPTION
У превьюх не выставляется нужный ранг при сортировке родителей, проверил - вроде достаточно одного запроса на $source для простановки ранга для превьюх, возможно и таргет тоже нужен, но работает и так корректно. По идее можно вообще обновлять ранг у всех превьюх конкретного товара, но зачем увеличивать нагрузку на sql?
