### PR TITLE
Возврат категорий

### DIFF
--- a/core/components/minishop2/processors/mgr/settings/option/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/settings/option/getlist.class.php
@@ -63,16 +63,14 @@ class msOptionGetListProcessor extends modObjectGetListProcessor
     {
         $data = $object->toArray();
 
-        $categories = $object->getMany('OptionCategories');
-        $data['categories'] = array();
-        /** @var msCategoryOption $cat */
-        foreach ($categories as $cat) {
-            $category = $cat->getOne('Category');
-            if ($category) {
-                $data['categories'][] = $category->get('id');
-            }
+        $category = (int)$this->getProperty('category', 0);
+        $categories = $this->getProperty('categories', '[]');
+        $categories = $this->modx->fromJSON($categories);
+        if($category>0){
+			$categories[]=$category;
         }
-        $data['categories'] = json_encode($data['categories']);
+
+        $data['categories'] = json_encode($categories);
 
         $data['actions'] = array(
             /*


### PR DESCRIPTION
Не нашел где вообще используется этот набор возвращенных категорий, но при 20 опциях и 300 категориях - этот весь процесс подвисает. Думаю надо возвращать только запрошенные категории, а не всё подряд, иначе 500 ошибка возникает связанная с нехваткой 128мб памяти
