### PR TITLE
Fixed name options

### DIFF
--- a/assets/components/minishop2/js/mgr/product/product.common.js
+++ b/assets/components/minishop2/js/mgr/product/product.common.js
@@ -650,7 +650,7 @@ Ext.extend(miniShop2.panel.Product, MODx.panel.Resource, {
                 category_name: options[i].category_name,
             });
 
-            field.name = 'options-' + options[i].key;
+            field.name = 'options-' + options[i].id;
             field = this.getExtField(config, options[i].key, field);
             fields.push(field);
         }

--- a/core/components/minishop2/processors/mgr/product/create.class.php
+++ b/core/components/minishop2/processors/mgr/product/create.class.php
@@ -44,12 +44,27 @@ class msProductCreateProcessor extends modResourceCreateProcessor
             ),
         ));
 
-        $properties = $this->getProperties();
         $options = array();
+        $option_ids = array();
+        $properties = $this->getProperties();
         foreach ($properties as $key => $value) {
             if (strpos($key, 'options-') === 0) {
-                $options[substr($key, 8)] = $value;
-                $this->unsetProperty($key);
+                $option_ids[] = substr($key, 8);
+            }
+        }
+
+        $q = $this->modx->newQuery('msOption');
+        $q->select(array('id', 'key'));
+        $q->where(array('id:IN' => $option_ids));
+        $q->limit(1000000);
+        if ($q->prepare() && $q->stmt->execute()) {
+            $option_fields = $q->stmt->fetchAll(PDO::FETCH_ASSOC);
+            foreach ($option_fields as $option) {
+                $key = 'options-' . $option['id'];
+                if (isset($properties[$key])) {
+                    $options[$option['key']] = $properties[$key];
+                    $this->unsetProperty($key);
+                }
             }
         }
         $this->setProperty('options', $options);

--- a/core/components/minishop2/processors/mgr/product/getoptions.class.php
+++ b/core/components/minishop2/processors/mgr/product/getoptions.class.php
@@ -9,7 +9,12 @@ class msProductGetOptionsProcessor extends modObjectProcessor
     {
         $query = trim($this->getProperty('query'));
         $limit = trim($this->getProperty('limit', 10));
-        $key = preg_replace('#^options-(.*?)#', '$1', $this->getProperty('key'));
+        $key = $this->getProperty('key');
+        if (preg_match('#^options-(.*?)#', $key)) {
+            $id = preg_replace('#^options-(.*?)#', '$1', $key);
+            $option = $this->modx->getObject('msOption', $id);
+            $key = $option->get('key');
+        }
 
         $c = $this->modx->newQuery('msProductOption');
         $c->sortby('value', 'ASC');

--- a/core/components/minishop2/processors/mgr/product/update.class.php
+++ b/core/components/minishop2/processors/mgr/product/update.class.php
@@ -40,11 +40,13 @@ class msProductUpdateProcessor extends modResourceUpdateProcessor
      */
     public function beforeSet()
     {
-        $properties = $this->getProperties();
         $options = array();
-        foreach ($properties as $key => $value) {
-            if (strpos($key, 'options-') === 0) {
-                $options[substr($key, 8)] = $value;
+        $properties = $this->getProperties();
+        $option_fields = $this->object->loadData()->getOptionFields();
+        foreach ($option_fields as $option) {
+            $key = 'options-' . $option['id'];
+            if (isset($properties[$key])) {
+                $options[$option['key']] = $properties[$key];
                 $this->unsetProperty($key);
             }
         }


### PR DESCRIPTION
Имена для опций переделаны по типу ТВ - **options-[[+id]]**.

У людей возникают проблемы с сохранением опций у товара. Как выяснилось, происходит это из-за точки или ещё какого символа в имени опции - MODX, в ключах массива POST, заменяет точку на "_", отсюда и невозможность сохранить опцию с ключом **options-key.number**, ибо MODX в процессор отсылает **options-key_number**.

Корректировки в PR помогут, не отказываясь от точек в названиях опций, решить данную проблему.
