### PR TITLE
Update JavaScript formatPrice

### DIFF
--- a/assets/components/minishop2/js/web/default.js
+++ b/assets/components/minishop2/js/web/default.js
@@ -288,7 +288,7 @@
                 }
                 $(miniShop2.Cart.totalWeight).text(miniShop2.Utils.formatWeight(status['total_weight']));
                 $(miniShop2.Cart.totalCount).text(status['total_count']);
-                $(miniShop2.Cart.totalCost).text(miniShop2.Utils.formatPrice(status['total_cost']));
+                $(miniShop2.Cart.totalCost).html(miniShop2.Utils.formatPrice(status['total_cost']));
                 if ($(miniShop2.Order.orderCost, miniShop2.Order.order).length) {
                     miniShop2.Order.getcost();
                 }
@@ -434,7 +434,7 @@
         getcost: function () {
             var callbacks = miniShop2.Order.callbacks;
             callbacks.getcost.response.success = function (response) {
-                $(miniShop2.Order.orderCost, miniShop2.Order.order).text(miniShop2.Utils.formatPrice(response.data['cost']));
+                $(miniShop2.Order.orderCost, miniShop2.Order.order).html(miniShop2.Utils.formatPrice(response.data['cost']));
             };
             var data = {};
             data[miniShop2.actionName] = 'order/getcost';


### PR DESCRIPTION
Возможность задать настройку
```
ms2_price_format = [2, ".", "&nbsp;"]
```
со значением неразрывного пробела.
`jQuery` функция для вставки значений в тэг`.text()` некорректно обрабатывает последовательность `&nbsp;`, она преобразует амперсанд. Вместо неё предлагается использовать `jQuery` функцию `html()` - она не затрагивает специальные последовательности, в частности, такую как неразрывные пробел, и конечно, не преобразует амперсанд. [Подробнее.](http://stackoverflow.com/questions/11953989/jquery-insert-nbsp-inside-label)