### PR TITLE
Добавление события msOnProductUpdateOrder

### DIFF
--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -40,6 +40,8 @@ $tmp = array(
 
     'msOnGetProductPrice',
     'msOnGetProductWeight',
+
+    'msOnProductUpdateOrder',
 );
 
 foreach ($tmp as $k => $v) {

--- a/core/components/minishop2/processors/mgr/orders/product/update.class.php
+++ b/core/components/minishop2/processors/mgr/orders/product/update.class.php
@@ -5,6 +5,7 @@ class msOrderProductUpdateProcessor extends modObjectUpdateProcessor
     public $classKey = 'msOrderProduct';
     public $languageTopics = array('minishop2:default');
     public $permission = 'msorder_save';
+    public $afterSaveEvent = 'msOnProductUpdateOrder';
     /** @var msOrder $order */
     protected $order;
 


### PR DESCRIPTION
Добавляет системное событие **msOnProductUpdateOrder** при редактировании покупок в заказе.

Это нужно для удобства работы с кастомными полями, например: высчитать себестоимость при изменении количества товара в заказе.

Существующие события **msOnUpdateOrder** и **msOnBeforeUpdateOrder** генерируют события только после нажатия "Сохранить" всего ордера. Например, если во втором окне произвести изменения поля "Количество", а в первом нажать "Отменить" - ни одно из этих событий не наступит, а по факту количество будет изменено.
![screenshot_20161115_175643](https://cloud.githubusercontent.com/assets/9001228/20331836/cd470c90-abc9-11e6-8653-988e6f6926d9.png)

Поэтому, не плохо было бы генерировать событие и при нажатии "Сохранить" второго окна.