### PR TITLE
Update default.js

### DIFF
--- a/assets/components/minishop2/js/web/default.js
+++ b/assets/components/minishop2/js/web/default.js
@@ -363,7 +363,6 @@
                     });
                 var $deliveryInputChecked = $(miniShop2.Order.deliveryInput + ':checked', miniShop2.Order.order);
                 $deliveryInputChecked.trigger('change');
-                miniShop2.Order.updatePayments($deliveryInputChecked.data('payments'));
             }
         },
         updatePayments: function (payments) {


### PR DESCRIPTION
Мне кажется вызов функции обновления способов оплаты здесь не уместен. Возникает баг, при котором не обновляются обязательные поля. Связано это с предшествующим вызовом тригера на change.
Вызывает событие change, которое вызывает функцию miniShop2.Order.add(), а она в свою очередь уже вызывает updatePayments()