### PR TITLE
Отметки чекбоксов во вкладке "Опции товара"

### DIFF
--- a/assets/components/minishop2/js/mgr/product/product.common.js
+++ b/assets/components/minishop2/js/mgr/product/product.common.js
@@ -653,6 +653,7 @@ Ext.extend(miniShop2.panel.Product, MODx.panel.Resource, {
             });
 
             field.name = 'options-' + options[i].key;
+            field.xtype == 'xcheckbox' && parseInt(field.value) == 1 ? field.checked = 1 : '';
             field = this.getExtField(config, options[i].key, field);
             fields.push(field);
         }


### PR DESCRIPTION
Проблема:
Если опция - чекбокс и в БД его статус 1, то раньше во вкладке товара "Опции товара", элементу этой опции не присваивался атрибут "checked".
Решение:
Добавил проверку типа input, проверку value и установку  атрибута "checked"