### PR TITLE
Добавлена смена контекста перед загрузкой лексиконов

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -689,6 +689,7 @@ class miniShop2
             /** @var modContext $context */
             if ($context = $this->modx->getObject('modContext', array('key' => $order->get('context')))) {
                 $this->modx->getCacheManager()->generateContext($context->get('key'));
+                $this->modx->switchContext($context->get('key'));
                 $lang = $context->getOption('cultureKey');
                 $this->modx->setOption('cultureKey', $lang);
                 $this->modx->lexicon->load($lang . ':minishop2:default', $lang . ':minishop2:cart');


### PR DESCRIPTION
У меня происходит следующее: при смене статуса заказа из менеджера(контекст mgr) в контексте mgr cultureKey устанавливается равной manager_language. Таким образом если язык сайта английский, а язык
менеджера русский, то пользователям будут приходить письма с русскими темами
и т.д. (если в чанках писем используются словари). Явно нужно сменить контекст перед загрузкой лексиконов, так как другого способа получить настройку cultureKey именно из контекста заказа я не нашёл.