### PR TITLE
Fix fatal error for settings/getclass processor

### DIFF
--- a/core/components/minishop2/processors/mgr/settings/getclass.class.php
+++ b/core/components/minishop2/processors/mgr/settings/getclass.class.php
@@ -19,7 +19,7 @@ class msClassGetListProcessor extends modProcessor
         $declared = array_diff(get_declared_classes(), $declared);
         $available = array();
         foreach ($declared as $class) {
-            if ($class == $handler) {
+            if ($class == $handler || strpos($class, 'Exception') !== false) {
                 continue;
             }
             try {


### PR DESCRIPTION
Fatal error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in getclass.class.php on line 30.

Error appear when custom classes of minishop use third-party library, which have extended Exception classes