### PR TITLE
Update minishop2.class.php

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -2,7 +2,7 @@
 
 class miniShop2
 {
-    public $version = '2.4.5-pl';
+    public $version = '2.4.11-pl';
     /** @var modX $modx */
     public $modx;
     /** @var pdoFetch $pdoTools */


### PR DESCRIPTION
Встретил глюк с подгрузкой JS на одном сайте из-за того, что JS-ы были версии 2.4.5-pl. Поменял в основном классе версию на 2.4.11-pl - все заработало.