### PR TITLE
validate receiver: allow accents and umlauts

### DIFF
--- a/core/components/minishop2/model/minishop2/msorderhandler.class.php
+++ b/core/components/minishop2/model/minishop2/msorderhandler.class.php
@@ -206,7 +206,7 @@ class msOrderHandler implements msOrderInterface
             case 'receiver':
                 // Transforms string from "nikolaj -  coster--Waldau jr." to "Nikolaj Coster-Waldau Jr."
                 $tmp = preg_replace(
-                    array('/[^-a-zа-яёЁ\s\.]/iu', '/\s+/', '/\-+/', '/\.+/'),
+                    array('/[^-a-zа-яäëïöüçÄËÏÖÜàéèîôûÀÉÈÎÔÛ\s\.]/iu', '/\s+/', '/\-+/', '/\.+/'),
                     array('', ' ', '-', '.'),
                     $value
                 );


### PR DESCRIPTION
The validate function filters accents (é, à, è) and umlauts (ä, ö, ü). In some languages they are needed.