### PR TITLE
it is better to specify exact type of user group ID variable

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -610,7 +610,7 @@ class miniShop2
                 if ($groups = $this->modx->getOption('ms2_order_user_groups', null, false)) {
                     $groups = array_map('trim', explode(',', $groups));
                     foreach ($groups as $group) {
-                        $user->joinGroup($group);
+                        $user->joinGroup((integer)$group);
                     }
                 }
                 $uid = $user->get('id');


### PR DESCRIPTION
Explicitly indicating the type of the variable, otherwise it does not add to the group, we have some strange error:
[2018-10-16 17:30:26] (ERROR @ /path_to/core/model/modx/moduser.class.php : 675) User Group not found with key: 3
Some more details were here: https://modx.pro/help/15072