### PR TITLE
Lexicon bug in default.js in v. 2.4.17

### DIFF
--- a/assets/components/minishop2/js/web/default.js
+++ b/assets/components/minishop2/js/web/default.js
@@ -557,7 +557,7 @@
                 });
             }
             else {
-                $.jGrowl.defaults.closerTemplate = '<div>[ ' + miniShop2Config.close_all_message + ' ]</div>';
+                $.jGrowl.defaults.closerTemplate = '<div>закрыть все</div>';//'<div>[ ' + miniShop2Config.close_all_message + ' ]</div>';
                 miniShop2.Message.close = function () {
                     $.jGrowl('close');
                 };


### PR DESCRIPTION
В версии 2.4.17 вместо записи из словаря ms2_message_close_all выводится просто [ms2_message_close_all].  В 2.4.16 это место работало правильно.
С моим изменением выводятся слова "закрыть все", но так делать точно нельзя, так что считайте моё изменение просто сообщением о баге, я, к сожалению, не знаю, как сделать правильно.