### PR TITLE
Ошибка сабмита заказа при большом количестве товаров

### DIFF
--- a/core/components/minishop2/elements/chunks/chunk.ms_email.tpl
+++ b/core/components/minishop2/elements/chunks/chunk.ms_email.tpl
@@ -114,6 +114,7 @@
                                         <strong>{$total.cost}</strong> {'ms2_frontend_currency' | lexicon}
                                     </h3>
                                 {/block}
+                                {block 'payment'}{/block}
                             </td>
                         </tr>
                     </table>

--- a/core/components/minishop2/elements/chunks/chunk.ms_email_new_user.tpl
+++ b/core/components/minishop2/elements/chunks/chunk.ms_email_new_user.tpl
@@ -4,8 +4,7 @@
     {'ms2_email_subject_new_user' | lexicon : $order}
 {/block}
 
-{block 'products'}
-    {parent}
+{block 'payment'}
     {if $payment_link?}
         <p style="margin-left:20px;{$style.p}">
             {'ms2_payment_link' | lexicon : ['link' => $payment_link]}


### PR DESCRIPTION
При болшом количестве уникальных товаров в корзине (больше 1000) заказ вылетал на отправке письма юзеру из-за наследования контента родителя с кучей кода, после разделения отрабатывает за секунды