### PR TITLE
Fixed resetting user id value on expand combobox

### DIFF
--- a/assets/components/minishop2/js/mgr/misc/ms2.combo.js
+++ b/assets/components/minishop2/js/mgr/misc/ms2.combo.js
@@ -81,6 +81,15 @@ miniShop2.combo.User = function (config) {
         ),
     });
     miniShop2.combo.User.superclass.constructor.call(this, config);
+    
+    var combo = this;
+    combo.on('render', function() {
+        combo.getStore().on('beforeload', function (store, data) {
+            if (!data.params['id']) {
+                data.params['id'] = combo.getValue();
+            }
+        });
+    });
 };
 Ext.extend(miniShop2.combo.User, MODx.combo.ComboBox);
 Ext.reg('minishop2-combo-user', miniShop2.combo.User);


### PR DESCRIPTION
Если у нас много юзеров (например 1к) и из них несколько, например, с именем "Дмитрий", то при оформлении нового заказа от "нового" Дмитрия, юзер назначается корректно. Но, если зайти в новый заказ, раскрыть список юзеров и в подгруженном списке не будет владельца заказа, но будет какой-то другой Дмитрий с другим ID юзера, а после этого закрыть список никого не выбрав и сохранить заказ, то user_id у заказа будет изменён на id того Дмитрия, который "не наш".
Надеюсь не запутал... попробуйте воспроизвести ситуацию, проблема реально есть! Сейчас на одном крупном сайте пытаюсь восстановить владельцев заказов из-за этого неприятного бага...