### PR TITLE
Передвинул вкладку "Галерея" перед вкладкой "Комментарии"

### DIFF
--- a/assets/components/minishop2/js/mgr/product/update.js
+++ b/assets/components/minishop2/js/mgr/product/update.js
@@ -119,15 +119,15 @@ Ext.extend(miniShop2.panel.UpdateProduct, miniShop2.panel.Product, {
             }
             var item = originals[i];
             if (item.id == 'modx-resource-tabs') {
-                // Additional "Comments" and "Gallery" tabs
-                if (miniShop2.config['show_comments'] != 0) {
-                    item.items.push(this.getComments(config));
-                }
+                // Additional "Gallery" and "Comments" tabs
                 if (miniShop2.config['show_gallery'] != 0) {
                     item.items.push(this.getGallery(config));
                 }
+                if (miniShop2.config['show_comments'] != 0) {
+                    item.items.push(this.getComments(config));
+                }
                 // Get the "Resource Groups" tab and move it to the end
-                if (miniShop2.config['show_comments'] != 0 || miniShop2.config['show_gallery'] != 0) {
+                if (miniShop2.config['show_gallery'] != 0 || miniShop2.config['show_comments'] != 0) {
                     var index = item.items.findIndex(function(tab) {
                         return tab.id == 'modx-resource-access-permissions';
                     });


### PR DESCRIPTION
### Что оно делает?
Не успел отправил коммит к предыдущему PR, а он уже влит :)

Подумал, что вкладка "Галерея" должна стоять перед вкладкой "Комментарии" (при установленном и включенном tickets). Т.к. "Галерея" это все-таки к наполнению товара относится, логичнее ее ближе расположить.

![tab](https://user-images.githubusercontent.com/12523676/66821556-b042c280-ef53-11e9-89ef-5f76afc2ca8b.png)

### Связанные проблема(ы)/PR(ы)
https://github.com/bezumkin/miniShop2/pull/376