### PR TITLE
fix error 500

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -543,24 +543,28 @@ class miniShop2
      */
     public function loadMap()
     {
-        $plugins = $this->loadPlugins();
-        foreach ($plugins as $plugin) {
-            // For legacy plugins
-            if (isset($plugin['xpdo_meta_map']) && is_array($plugin['xpdo_meta_map'])) {
-                $plugin['map'] = $plugin['xpdo_meta_map'];
-            }
-            if (isset($plugin['map']) && is_array($plugin['map'])) {
-                foreach ($plugin['map'] as $class => $map) {
-                    if (!isset($this->modx->map[$class])) {
-                        $this->modx->loadClass($class, $this->config['modelPath'] . 'minishop2/');
-                    }
-                    if (isset($this->modx->map[$class])) {
-                        foreach ($map as $key => $values) {
-                            $this->modx->map[$class][$key] = array_merge($this->modx->map[$class][$key], $values);
+        if(method_exists($this->pdoTools, 'makePlaceholders')) {
+            $plugins = $this->loadPlugins();
+            foreach ($plugins as $plugin) {
+                // For legacy plugins
+                if (isset($plugin['xpdo_meta_map']) && is_array($plugin['xpdo_meta_map'])) {
+                    $plugin['map'] = $plugin['xpdo_meta_map'];
+                }
+                if (isset($plugin['map']) && is_array($plugin['map'])) {
+                    foreach ($plugin['map'] as $class => $map) {
+                        if (!isset($this->modx->map[$class])) {
+                            $this->modx->loadClass($class, $this->config['modelPath'] . 'minishop2/');
+                        }
+                        if (isset($this->modx->map[$class])) {
+                            foreach ($map as $key => $values) {
+                                $this->modx->map[$class][$key] = array_merge($this->modx->map[$class][$key], $values);
+                            }
                         }
                     }
                 }
             }
+        } else {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'pdoTools not installed, metadata for miniShop2 objects not loaded');
         }
     }
 


### PR DESCRIPTION
### Что оно делает?
HTTP ERROR 500 #380 
Исправление 500 ошибки если не установило pdoTools

### Зачем это нужно?

Исправляет ошибку если в процессе установки не установило pdoTools, отключает генерацию loadMap(подключение сторонних плагинов если не установлен pdoTools), что разрешает работать в админке и на сайте. Чтобы не отключать плагин minishop2, и потом устанавливать pdoTools, а сразу посмотрев логи установить pdoTools.

### Связанные проблема(ы)/PR(ы)
https://modx.pro/help/11203
