### PR TITLE
Fix miniShop2.combo.Options paging on local mode

### DIFF
--- a/assets/components/minishop2/js/mgr/misc/ms2.combo.js
+++ b/assets/components/minishop2/js/mgr/misc/ms2.combo.js
@@ -283,6 +283,14 @@ Ext.reg('minishop2-combo-source', miniShop2.combo.Source);
 
 miniShop2.combo.Options = function (config) {
     config = config || {};
+
+    if (config.mode == 'remote') {
+        Ext.applyIf(config, {
+            pageSize: 10,
+            paging: true,
+        });
+    }
+
     Ext.applyIf(config, {
         xtype: 'superboxselect',
         allowBlank: true,
@@ -296,7 +304,6 @@ miniShop2.combo.Options = function (config) {
         name: config.name || 'tags',
         anchor: '100%',
         minChars: 1,
-        pageSize: 10,
         store: new Ext.data.JsonStore({
             id: (config.name || 'tags') + '-store',
             root: 'results',


### PR DESCRIPTION
### Что оно делает?

Выводит пагинацию, только при mode remote у **minishop2-combo-options**

### Зачем это нужно?

Если mode local, то пагинация приводит к ошибке

### Связанные проблема(ы)/PR(ы)

#399
