### PR TITLE
Display field key if caption and lexicon entry is empty

### DIFF
--- a/assets/components/minishop2/js/mgr/misc/ms2.utils.js
+++ b/assets/components/minishop2/js/mgr/misc/ms2.utils.js
@@ -305,7 +305,7 @@ miniShop2.utils.getExtField = function (config, key, option, context) {
         name: name,
         value: option.value || config.record[key] || '',
         description: '[[+' + key + ']]' + help,
-        fieldLabel: option.caption || _('ms2_product_' + key),
+        fieldLabel: option.caption || _('ms2_product_' + key) || key,
         fieldKey: key,
         allowBlank: Boolean(1 - parseInt(option.required || 0)),
         enableKeyEvents: true,


### PR DESCRIPTION
### Что оно делает?

Выводит ключ поля при отсутствии caption и записи в лексиконах

### Зачем это нужно?

Если создать опцию товара без названия, то на странице ресурса поле выводится без заголовка, что в свою очередь нелогично