### PR TITLE
fix check array empty

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
@@ -3,6 +3,8 @@
 /** @var array $scriptProperties */
 
 $tpl = $modx->getOption('tpl', $scriptProperties, 'tpl.msOptions');
+$showEmpty = $modx->getOption('showEmpty', $scriptProperties, 1);
+
 if (!empty($input) && empty($product)) {
     $product = $input;
 }
@@ -45,7 +47,7 @@ foreach ($optionKeys as $key) {
     }
     $option['value'] = $product->get($key);
     
-    if (is_array($option['value'])){
+    if (is_array($option['value']) && !$showEmpty){
         $option['value'] = array_values(
             array_filter($option['value'], function($var){
                 return $var !== '';

--- a/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
@@ -50,7 +50,7 @@ foreach ($optionKeys as $key) {
     if (is_array($option['value']) && !$showEmpty){
         $option['value'] = array_values(
             array_filter($option['value'], function($var){
-                return $var !== '';
+                return $var !== '' && $var !== null;
             })
         );
     }

--- a/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
@@ -3,7 +3,7 @@
 /** @var array $scriptProperties */
 
 $tpl = $modx->getOption('tpl', $scriptProperties, 'tpl.msOptions');
-$showEmpty = $modx->getOption('showEmpty', $scriptProperties, 1);
+$showEmpty = $modx->getOption('showEmpty', $scriptProperties, 0);
 
 if (!empty($input) && empty($product)) {
     $product = $input;

--- a/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_product_options.php
@@ -44,6 +44,14 @@ foreach ($optionKeys as $key) {
         }
     }
     $option['value'] = $product->get($key);
+    
+    if (is_array($option['value'])){
+        $option['value'] = array_values(
+            array_filter($option['value'], function($var){
+                return $var !== '';
+            })
+        );
+    }
 
     // Filter by groups
     $skip = !empty($groups) && !in_array($option['category'], $groups) && !in_array($option['category_name'], $groups);


### PR DESCRIPTION
### Что оно делает?

Исправляет проверку на пустой массив

### Зачем это нужно?

В оригинале не работает проверка empty($option['value']) если это массив, и выводятся пустые опции