### PR TITLE
#403 Ext.Loader remove asynchronous loading of strftime-min-1.3.js

### DIFF
--- a/assets/components/minishop2/js/mgr/misc/ms2.utils.js
+++ b/assets/components/minishop2/js/mgr/misc/ms2.utils.js
@@ -1,7 +1,3 @@
-Ext.Loader.load([
-    MODx.config.assets_url + 'components/minishop2/js/mgr/misc/strftime-min-1.3.js'
-]);
-
 Ext.namespace('miniShop2.utils');
 
 miniShop2.utils.formatDate = function (string) {

--- a/core/components/minishop2/controllers/category/update.class.php
+++ b/core/components/minishop2/controllers/category/update.class.php
@@ -76,6 +76,7 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
         $this->addJavascript($mgrUrl . 'assets/modext/sections/resource/update.js');
         $this->addJavascript($assetsUrl . 'js/mgr/minishop2.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/ms2.combo.js');
+        $this->addJavascript($assetsUrl . 'js/mgr/misc/strftime-min-1.3.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/ms2.utils.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/default.grid.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/default.window.js');

--- a/core/components/minishop2/controllers/mgr/orders.class.php
+++ b/core/components/minishop2/controllers/mgr/orders.class.php
@@ -34,6 +34,7 @@ class Minishop2MgrOrdersManagerController extends msManagerController
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/minishop2.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/default.grid.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/default.window.js');
+        $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/strftime-min-1.3.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/ms2.utils.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/ms2.combo.js');
 

--- a/core/components/minishop2/controllers/mgr/settings.class.php
+++ b/core/components/minishop2/controllers/mgr/settings.class.php
@@ -34,6 +34,7 @@ class Minishop2MgrSettingsManagerController extends msManagerController
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/minishop2.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/default.grid.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/default.window.js');
+        $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/strftime-min-1.3.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/ms2.utils.js');
         $this->addJavascript($this->miniShop2->config['jsUrl'] . 'mgr/misc/ms2.combo.js');
 

--- a/core/components/minishop2/controllers/product/update.class.php
+++ b/core/components/minishop2/controllers/product/update.class.php
@@ -51,6 +51,7 @@ class msProductUpdateManagerController extends msResourceUpdateController
         $this->addJavascript($assetsUrl . 'js/mgr/minishop2.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/sortable/sortable.min.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/ms2.combo.js');
+        $this->addJavascript($assetsUrl . 'js/mgr/misc/strftime-min-1.3.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/ms2.utils.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/default.grid.js');
         $this->addJavascript($assetsUrl . 'js/mgr/misc/default.window.js');


### PR DESCRIPTION
### Что оно делает?
Удаляет загрузку strftime-min-1.3.js Ext.Loader'ом
И добавляет синхронную загрузку

### Зачем это нужно?
Ext периодически не успевает загрузить скрипт до вызова его функционала
