### PR TITLE
Изменение любых полей продукта по событию msOnGetProductFields

### DIFF
--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -47,6 +47,7 @@ $tmp = array(
 
     'msOnGetProductPrice',
     'msOnGetProductWeight',
+    'msOnGetProductFields',
 
     'msOnManagerCustomCssJs',
 

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -189,7 +189,6 @@ if (!empty($rows) && is_array($rows)) {
     foreach ($rows as $k => $row) {
         if ($modifications) {
             $product->fromArray($row, '', true, true);
-            $old_fields = $row;
             $row = $product->prepareFields($row);
         }
         $row['price'] = $miniShop2->formatPrice($row['price']);

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -177,8 +177,7 @@ if (!empty($rows) && is_array($rows)) {
     $c->innerJoin('modPlugin', 'modPlugin', 'modPlugin.id = modPluginEvent.pluginid');
     $c->where('modPlugin.disabled = 0');
 
-    $
-        = $modx->getOption('ms2_price_snippet', null, false, true) ||
+    $modifications = $modx->getOption('ms2_price_snippet', null, false, true) ||
         $modx->getOption('ms2_weight_snippet', null, false, true) || $modx->getCount('modPluginEvent', $c);
     if ($modifications) {
         /** @var msProductData $product */

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -177,7 +177,8 @@ if (!empty($rows) && is_array($rows)) {
     $c->innerJoin('modPlugin', 'modPlugin', 'modPlugin.id = modPluginEvent.pluginid');
     $c->where('modPlugin.disabled = 0');
 
-    $modifications = $modx->getOption('ms2_price_snippet', null, false, true) ||
+    $
+        = $modx->getOption('ms2_price_snippet', null, false, true) ||
         $modx->getOption('ms2_weight_snippet', null, false, true) || $modx->getCount('modPluginEvent', $c);
     if ($modifications) {
         /** @var msProductData $product */
@@ -189,6 +190,13 @@ if (!empty($rows) && is_array($rows)) {
     foreach ($rows as $k => $row) {
         if ($modifications) {
             $product->fromArray($row, '', true, true);
+            $tmp = $row['price'];
+            $row['price'] = $product->getPrice($row);	
+            $row['weight'] = $product->getWeight($row);	
+            // A discount here, so we should replace old price	
+            if ($row['price'] < $tmp) {	
+                $row['old_price'] = $tmp;	
+            }
             $row = $product->prepareFields($row);
         }
         $row['price'] = $miniShop2->formatPrice($row['price']);

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -193,7 +193,7 @@ if (!empty($rows) && is_array($rows)) {
             $tmp = $row['price'];
             $row['price'] = $product->getPrice($row);
             $row['weight'] = $product->getWeight($row);
-            // A discount here, so we should replace old price	
+            // A discount here, so we should replace old price
             if ($row['price'] < $tmp) {
                 $row['old_price'] = $tmp;
             }

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -173,7 +173,7 @@ $rows = $pdoFetch->run();
 // Process rows
 $output = array();
 if (!empty($rows) && is_array($rows)) {
-    $c = $modx->newQuery('modPluginEvent', array('event:IN' => array('msOnGetProductPrice', 'msOnGetProductWeight')));
+    $c = $modx->newQuery('modPluginEvent', array('event:IN' => array('msOnGetProductPrice', 'msOnGetProductWeight', 'msOnGetProductFields')));
     $c->innerJoin('modPlugin', 'modPlugin', 'modPlugin.id = modPluginEvent.pluginid');
     $c->where('modPlugin.disabled = 0');
 
@@ -189,13 +189,8 @@ if (!empty($rows) && is_array($rows)) {
     foreach ($rows as $k => $row) {
         if ($modifications) {
             $product->fromArray($row, '', true, true);
-            $tmp = $row['price'];
-            $row['price'] = $product->getPrice($row);
-            $row['weight'] = $product->getWeight($row);
-            // A discount here, so we should replace old price
-            if ($row['price'] < $tmp) {
-                $row['old_price'] = $tmp;
-            }
+            $old_fields = $row;
+            $row = $product->prepareFields($row);
         }
         $row['price'] = $miniShop2->formatPrice($row['price']);
         $row['old_price'] = $miniShop2->formatPrice($row['old_price']);

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -191,11 +191,11 @@ if (!empty($rows) && is_array($rows)) {
         if ($modifications) {
             $product->fromArray($row, '', true, true);
             $tmp = $row['price'];
-            $row['price'] = $product->getPrice($row);	
-            $row['weight'] = $product->getWeight($row);	
+            $row['price'] = $product->getPrice($row);
+            $row['weight'] = $product->getWeight($row);
             // A discount here, so we should replace old price	
-            if ($row['price'] < $tmp) {	
-                $row['old_price'] = $tmp;	
+            if ($row['price'] < $tmp) {
+                $row['old_price'] = $tmp;
             }
             $row = $product->prepareFields($row);
         }

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -196,7 +196,7 @@ if (!empty($rows) && is_array($rows)) {
             if ($row['price'] < $tmp) {
                 $row['old_price'] = $tmp;
             }
-            $row = $product->prepareFields($row);
+            $row = $product->modifyFields($row);
         }
         $row['price'] = $miniShop2->formatPrice($row['price']);
         $row['old_price'] = $miniShop2->formatPrice($row['old_price']);

--- a/core/components/minishop2/model/minishop2/msproduct.class.php
+++ b/core/components/minishop2/model/minishop2/msproduct.class.php
@@ -525,4 +525,14 @@ class msProduct extends modResource
     {
         return $this->loadData()->getWeight($data);
     }
+
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     */
+    public function prepareFields($data = array()) {
+        return $this->loadData()->prepareFields($data);
+    }
 }

--- a/core/components/minishop2/model/minishop2/msproduct.class.php
+++ b/core/components/minishop2/model/minishop2/msproduct.class.php
@@ -456,10 +456,11 @@ class msProduct extends modResource
             if ($pls['price'] < $tmp) {
                 $pls['old_price'] = $tmp;
             }
-            $pls = $this->prepareFields($pls);
+            $pls['weight'] = $this->getWeight($pls);
+            $pls = $this->modifyFields($pls);
             $pls['price'] = $miniShop2->formatPrice($pls['price']);
             $pls['old_price'] = $miniShop2->formatPrice($pls['old_price']);
-            $pls['weight'] = $miniShop2->formatWeight($this->getWeight($pls));
+            $pls['weight'] = $miniShop2->formatWeight($pls['weight']);
             unset($pls['id']);
 
             $this->xpdo->setPlaceholders($pls);
@@ -533,7 +534,7 @@ class msProduct extends modResource
      *
      * @return array
      */
-    public function prepareFields($data = array()) {
-        return $this->loadData()->prepareFields($data);
+    public function modifyFields($data = array()) {
+        return $this->loadData()->modifyFields($data);
     }
 }

--- a/core/components/minishop2/model/minishop2/msproduct.class.php
+++ b/core/components/minishop2/model/minishop2/msproduct.class.php
@@ -456,6 +456,7 @@ class msProduct extends modResource
             if ($pls['price'] < $tmp) {
                 $pls['old_price'] = $tmp;
             }
+            $pls = $this->prepareFields($pls);
             $pls['price'] = $miniShop2->formatPrice($pls['price']);
             $pls['old_price'] = $miniShop2->formatPrice($pls['old_price']);
             $pls['weight'] = $miniShop2->formatWeight($this->getWeight($pls));

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -627,4 +627,29 @@ class msProductData extends xPDOSimpleObject
 
         return $weight;
     }
+
+
+    /* Returns prepared product fields.
+     *
+     * @return array $result Prepared fields of product.
+     * */
+    public function prepareFields() {
+
+        $data = $this->toArray();
+        /** @var miniShop2 $miniShop2 */
+        $miniShop2 = $this->xpdo->getService('minishop2');
+        $params = array(
+            'product' => $this,
+            'data' => $data,
+        );
+        $response = $miniShop2->invokeEvent('msOnGetProductFields', $params);
+        if ($response['success']) {
+            unset($response['data']['product']);
+            $result = array_merge($data, $response['data']);
+        } else {
+            $result = $data;
+        }
+
+        return $result;
+    }
 }

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -645,9 +645,9 @@ class msProductData extends xPDOSimpleObject
         );
         $response = $miniShop2->invokeEvent('msOnGetProductFields', $params);
         if ($response['success']) {
-            $result = array_merge($data, $response['data']);
+            $data = array_merge($data, $response['data']);
         }
 
-        return $result;
+        return $data;
     }
 }

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -633,9 +633,7 @@ class msProductData extends xPDOSimpleObject
      *
      * @return array $result Prepared fields of product.
      * */
-    public function modifyFields() {
-
-        $data = $this->toArray();
+    public function modifyFields($data = array()) {
         /** @var miniShop2 $miniShop2 */
         $miniShop2 = $this->xpdo->getService('minishop2');
         $params = array(

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -633,7 +633,7 @@ class msProductData extends xPDOSimpleObject
      *
      * @return array $result Prepared fields of product.
      * */
-    public function prepareFields() {
+    public function modifyFields() {
 
         $data = $this->toArray();
         /** @var miniShop2 $miniShop2 */

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -645,10 +645,7 @@ class msProductData extends xPDOSimpleObject
         );
         $response = $miniShop2->invokeEvent('msOnGetProductFields', $params);
         if ($response['success']) {
-            unset($response['data']['product']);
             $result = array_merge($data, $response['data']);
-        } else {
-            $result = $data;
         }
 
         return $result;

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -634,6 +634,9 @@ class msProductData extends xPDOSimpleObject
      * @return array $result Prepared fields of product.
      * */
     public function modifyFields($data = array()) {
+        if (empty($data)) {
+            $data = $this->toArray();
+        }
         /** @var miniShop2 $miniShop2 */
         $miniShop2 = $this->xpdo->getService('minishop2');
         $params = array(


### PR DESCRIPTION
### Что оно делает?

Добавил событие msOnGetProductFields для возможности изменения любых полей продукта при его получении.
Заменил два отдельных вызовов методов getPrice() и getWeight() на один вызов метода prepareFields().

### Зачем это нужно?

Была задача менять цену товара в зависимости от курса рубля к доллару. При пересчёте надо было менять не только price, но и old_price. К сожалению изменение старой цены прибито гвоздями в коде, поэтому пришлось добавить еще один метод к продукту - prepareFields. Он полностью заменяет методы getPrice и getWeight, хотя их в коде оставляю в целях обратной совместимости.

