### PR TITLE
Более удобный выбор чанка в окнах создания/редактирования статусов

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -37,6 +37,11 @@ $tmp = array(
         'xtype' => 'textarea',
         'area' => 'ms2_main',
     ),
+    'ms2_chunks_categories' => array(
+        'value' => '',
+        'xtype' => 'textfield',
+        'area' => 'ms2_main',
+    ),
 
     'ms2_category_grid_fields' => array(
         'value' => 'id,menuindex,pagetitle,article,price,thumb,new,favorite,popular',

--- a/_build/resolvers/resolve.settings.php
+++ b/_build/resolvers/resolve.settings.php
@@ -164,6 +164,37 @@ if ($transport->xpdo) {
                     }
                 }
             }
+
+            $chunks_descriptions = array(
+                'msProduct.content' => !$lang ? 'Чанк вывода карточки товара.' : 'Chunk for displaying card of miniShop2 product.',
+                'tpl.msProducts.row' => !$lang ? 'Чанк товара miniShop2.' : 'Chunk for listing miniShop2 catalog.',
+
+                'tpl.msCart' => !$lang ? 'Чанк вывода корзины miniShop2.' : 'Chunk for miniShop2 cart.',
+                'tpl.msMiniCart' => !$lang ? 'Чанк вывода мини корзины miniShop2.' : 'Chunk for miniShop2 mini cart.',
+                'tpl.msOrder' => !$lang ? 'Чанк вывода формы оформления заказа miniShop2.' : 'Chunk for displaying order form of miniShop2.',
+                'tpl.msGetOrder' => !$lang ? 'Чанк вывода заказа miniShop2.' : 'Chunk for displaying order of miniShop2.',
+                'tpl.msOptions' => !$lang ? 'Чанк вывода дополнительных свойств товара miniShop2.' : 'Chunk for displaying additional product characteristics of miniShop2 product.',
+                'tpl.msProductOptions' => !$lang ? 'Чанк вывода дополнительных опций товара miniShop2.' : 'Chunk for displaying additional product options of miniShop2 product.',
+                'tpl.msGallery' => !$lang ? 'Чанк вывода галереи товара miniShop2.' : 'Chunk for displaying gallery of miniShop2 product.',
+
+                'tpl.msEmail' => !$lang ? 'Базовый чанк оформления писем miniShop2.' : 'Basic mail chunk of miniShop2 mail.',
+                'tpl.msEmail.new.user' => !$lang ? 'Чанк письма нового заказа пользователю.' : 'User new order mail chunk.',
+                'tpl.msEmail.new.manager' => !$lang ? 'Чанк письма нового заказа менеджеру.' : 'Manager new order mail chunk.',
+                'tpl.msEmail.paid.user' => !$lang ? 'Чанк письма оплаченного заказа пользователю.' : 'User paid order mail chunk.',
+                'tpl.msEmail.paid.manager' => !$lang ? 'Чанк письма оплаченного заказа менеджеру.' : 'Manager paid order mail chunk.',
+                'tpl.msEmail.sent.user' => !$lang ? 'Чанк письма отправленного заказа пользователю.' : 'User sent order mail chunk.',
+                'tpl.msEmail.cancelled.user' => !$lang ? 'Чанк письма отмененного заказа пользователю.' : 'User cancelled order mail chunk.',
+            );
+
+            foreach ($chunks_descriptions as $name => $description) {
+                /** @var modChunk $chunk */
+                if ($chunk = $modx->getObject('modChunk', array('name' => $name))) {
+                    if (!$chunk->get('locked') && empty($chunk->get('description'))) {
+                        $chunk->set('description', $description);
+                        $chunk->save();
+                    }
+                }
+            }
             break;
 
         case xPDOTransport::ACTION_UNINSTALL:

--- a/_build/resolvers/resolve.settings.php
+++ b/_build/resolvers/resolve.settings.php
@@ -153,6 +153,17 @@ if ($transport->xpdo) {
                     $item->remove();
                 }
             }
+
+            /** @var modSystemSetting $setting */
+            if ($setting = $modx->getObject('modSystemSetting', array('key' => 'ms2_chunks_categories'))) {
+                if (!$setting->get('editedon')) {
+                    /** @var modCategory $category */
+                    if ($category = $modx->getObject('modCategory', array('category' => 'miniShop2'))) {
+                        $setting->set('value', $category->get('id'));
+                        $setting->save();
+                    }
+                }
+            }
             break;
 
         case xPDOTransport::ACTION_UNINSTALL:

--- a/assets/components/minishop2/js/mgr/misc/ms2.combo.js
+++ b/assets/components/minishop2/js/mgr/misc/ms2.combo.js
@@ -525,7 +525,18 @@ miniShop2.combo.Chunk = function (config) {
         baseParams: {
             action: 'mgr/system/element/chunk/getlist',
             mode: 'chunks'
-        }
+        },
+        tpl: new Ext.XTemplate('\
+            <tpl for=".">\
+                <div class="x-combo-list-item">\
+                    <span>\
+                        <small>({id})</small>\
+                        <b>{name}</b>\
+                    </span>\
+                </div>\
+            </tpl>',
+            {compiled: true}
+        ),
     });
     miniShop2.combo.Chunk.superclass.constructor.call(this, config);
 };

--- a/assets/components/minishop2/js/mgr/settings/status/window.js
+++ b/assets/components/minishop2/js/mgr/settings/status/window.js
@@ -3,7 +3,7 @@ miniShop2.window.CreateStatus = function (config) {
     this.ident = config.ident || 'mecitem' + Ext.id();
     Ext.applyIf(config, {
         title: _('ms2_menu_create'),
-        width: 600,
+        width: 800,
         baseParams: {
             action: 'mgr/settings/status/create',
         },

--- a/core/components/minishop2/lexicon/en/setting.inc.php
+++ b/core/components/minishop2/lexicon/en/setting.inc.php
@@ -18,6 +18,8 @@ $_lang['setting_ms2_services'] = 'Store services';
 $_lang['setting_ms2_services_desc'] = 'Array with registered classes for cart, order, delivery and payment. Used by third-party extras to load their functionality.';
 $_lang['setting_ms2_plugins'] = 'Store plugins';
 $_lang['setting_ms2_plugins_desc'] = 'Array with registered plugins for extension objects of store model: products, customer profiles, etc.';
+$_lang['setting_ms2_chunks_categories'] = 'Categories for list chunks';
+$_lang['setting_ms2_chunks_categories_desc'] = 'List of category IDs for list chunks by comma separated.';
 
 $_lang['setting_ms2_category_grid_fields'] = 'Fields of the table with goods';
 $_lang['setting_ms2_category_grid_fields_desc'] = 'Comma separated list of visible fields in the table of goods in category.';

--- a/core/components/minishop2/processors/mgr/system/element/chunk/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/system/element/chunk/getlist.class.php
@@ -14,15 +14,41 @@ class msChunkGetListProcessor extends modObjectGetListProcessor
      */
     public function prepareQueryBeforeCount(xPDOQuery $c)
     {
+        $categories = $this->modx->getOption('ms2_chunks_categories');
+        if (!empty($categories)) {
+            $c->where(array(
+                'category:IN' => explode(',',$categories)
+            ));
+        }
         if ($id = (int)$this->getProperty('id')) {
             $c->where(array('id' => $id));
         }
         if ($query = trim($this->getProperty('query'))) {
-            $c->where(array('name:LIKE' => "%{$query}%"));
+            $c->where(array(
+                'name:LIKE' => "%{$query}%",
+                'OR:description:LIKE' => "%{$query}%",
+            ));
         }
 
         return $c;
     }
+
+
+    /**
+     * @param xPDOObject $object
+     * 
+     * @return array
+     */
+    public function prepareRow(xPDOObject $object)
+    {
+        $array = $object->toArray();
+
+		if (!empty($array['description'])) {
+			$array['name'] = $array['description'];
+        }
+
+		return $array;
+	}
 
 }
 

--- a/core/components/minishop2/processors/mgr/system/element/chunk/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/system/element/chunk/getlist.class.php
@@ -43,12 +43,12 @@ class msChunkGetListProcessor extends modObjectGetListProcessor
     {
         $array = $object->toArray();
 
-		if (!empty($array['description'])) {
-			$array['name'] = $array['description'];
+        if (!empty($array['description'])) {
+            $array['name'] = $array['description'];
         }
 
-		return $array;
-	}
+        return $array;
+    }
 
 }
 


### PR DESCRIPTION
### Что оно делает?

1. Добавляет новую сис. настройку `ms2_chunks_categories` и в первый раз при установке/обновлении компонента устанавливает значение категории ms2
2. В списке чанков отображается description вместо name если он заполнен и id чанка
3. В combo.Chunk можно искать и по description
4. Изменяет ширину окон создания/редактирования статусов с 600 до 800 пикс.
5. Добавляет описания к чанкам ms2

![image](https://user-images.githubusercontent.com/20814058/81338283-8f4fe380-90d6-11ea-931b-01cfd710e11f.png)


### Зачем это нужно?

Так лучше.

### Связанные проблема(ы)/PR(ы)

Closes #416 
