### PR TITLE
Иконки изображения для полей с логотипами и ограничение форматов из сис. настройки

### DIFF
--- a/assets/components/minishop2/js/mgr/settings/delivery/window.js
+++ b/assets/components/minishop2/js/mgr/settings/delivery/window.js
@@ -92,7 +92,9 @@ Ext.extend(miniShop2.window.CreateDelivery, miniShop2.window.Default, {
             fieldLabel: _('ms2_logo'),
             name: 'logo',
             anchor: '99%',
-            id: config.id + '-logo'
+            id: config.id + '-logo',
+            triggerClass: 'x-form-image-trigger',
+            allowedFileTypes: config.allowedFileTypes || MODx.config.upload_images
         }, {
             xtype: 'textarea',
             fieldLabel: _('ms2_description'),

--- a/assets/components/minishop2/js/mgr/settings/payment/window.js
+++ b/assets/components/minishop2/js/mgr/settings/payment/window.js
@@ -61,7 +61,9 @@ Ext.extend(miniShop2.window.CreatePayment, miniShop2.window.Default, {
             fieldLabel: _('ms2_logo'),
             name: 'logo',
             anchor: '99%',
-            id: config.id + '-logo'
+            id: config.id + '-logo',
+            triggerClass: 'x-form-image-trigger',
+            allowedFileTypes: config.allowedFileTypes || MODx.config.upload_images
         }, {
             xtype: 'textarea',
             fieldLabel: _('ms2_description'),

--- a/assets/components/minishop2/js/mgr/settings/vendor/window.js
+++ b/assets/components/minishop2/js/mgr/settings/vendor/window.js
@@ -67,7 +67,9 @@ Ext.extend(miniShop2.window.CreateVendor, miniShop2.window.Default, {
                 fieldLabel: _('ms2_logo'),
                 name: 'logo',
                 anchor: '99%',
-                id: config.id + '-logo'
+                id: config.id + '-logo',
+                triggerClass: 'x-form-image-trigger',
+                allowedFileTypes: config.allowedFileTypes || MODx.config.upload_images
             }, {
                 xtype: 'textarea',
                 fieldLabel: _('ms2_address'),


### PR DESCRIPTION
### Что оно делает?

Добавляет иконку изображения и ограничивает выбор файлов из системной настройки upload_images

**До:**

![image](https://user-images.githubusercontent.com/20814058/81355301-50328a00-90f8-11ea-9ab5-fc3bc619e2de.png)

**После:**

![image](https://user-images.githubusercontent.com/20814058/81355337-6fc9b280-90f8-11ea-89c6-811880f91b1a.png)


### Зачем это нужно?

Странно видеть иконку которая подсказывает будто у нас дропдаун когда вызывается окно выбора файла, ну и отсутствие ограничения по форматам файлов тоже нелогично. Т.е. я спокойно могу выбрать php файл
