### PR TITLE
Расширение функционала окон быстрого создания/обновления товара/категории

### DIFF
--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -13,6 +13,7 @@ $tmp = array(
             'OnWebPageInit',
             'OnUserSave',
             'msOnChangeOrderStatus',
+            'OnManagerPageBeforeRender',
         ),
     ),
 );

--- a/assets/components/minishop2/js/mgr/misc/ms2.manager.js
+++ b/assets/components/minishop2/js/mgr/misc/ms2.manager.js
@@ -1,0 +1,74 @@
+Ext.override(MODx.window.QuickCreateResource, {
+    listeners: {
+        show: function() {
+            var classKey = this.config.record.class_key,
+                isProduct = classKey == 'msProduct',
+                class_key = isProduct ? 'ms2_product' : 'ms2_category',
+                windowTitle = _(class_key + '_create_here');
+
+            if (['msProduct', 'msCategory'].includes(classKey)) {
+                switch (this.action) {
+                    case 'resource/create':
+                        var form = this.fp.getForm(),
+                            templateCmb = form.findField('template'),
+                            templateCmbStore = templateCmb.getStore(),
+                            templateSettingKey = isProduct ? 'ms2_template_product_default' : 'ms2_template_category_default',
+                            templateVal = MODx.config[templateSettingKey] || MODx.config.default_template,
+                            contentSettingKey = 'ms2_category_content_default',
+                            contentCmb = form.findField('content'),
+                            contentVal = MODx.config[contentSettingKey];
+
+                        MODx.Ajax.request({
+                            url: MODx.config.connector_url,
+                            params: {
+                                action: 'context/setting/getlist',
+                                context_key: this.config.record.context_key
+                            },
+                            listeners: {fn: function() {}, scope: this},
+                            callback: function(options, success, response) {
+                                var r = JSON.parse(response.responseText),
+                                    settings = r.results;
+
+                                if (success && settings) {
+                                    for (var prop in settings) {
+                                        switch (settings[prop].key) {
+                                            case templateSettingKey:
+                                                templateVal = settings[prop].value;
+                                                continue;
+                                            case contentSettingKey:
+                                                contentVal = settings[prop].value;
+                                                continue;
+                                        }
+                                    }
+                                }
+
+                                if (templateCmb && templateCmbStore) {
+                                    templateCmbStore.on('load', function() {
+                                        if (templateCmb.getValue() != templateVal) {
+                                            templateCmb.setValue(templateVal);
+                                        }
+                                    });
+                                    templateCmbStore.load();
+                                }
+
+                                if (contentCmb && !isProduct && contentCmb.getValue() != contentVal) {
+                                    contentCmb.setValue(contentVal);
+                                }
+                            }
+                        });
+
+                        this._setTitle(_('quick_create'), windowTitle);
+                        break;
+                    case 'resource/update':
+                        this._setTitle(_('quick_update'), windowTitle);
+                        break;
+                }
+            }
+        }
+    },
+    _setTitle: function(prefix, title) {
+        if (title != 'undefined') {
+            this.setTitle(prefix + ' ' + title.toLowerCase());
+        }
+    }
+});

--- a/assets/components/minishop2/js/mgr/misc/ms2.manager.js
+++ b/assets/components/minishop2/js/mgr/misc/ms2.manager.js
@@ -31,6 +31,9 @@ Ext.override(MODx.window.QuickCreateResource, {
 
                                 if (success && settings) {
                                     for (var prop in settings) {
+                                        if (!settings.hasOwnProperty(prop)) {
+                                            continue;
+                                        }
                                         switch (settings[prop].key) {
                                             case templateSettingKey:
                                                 templateVal = settings[prop].value;

--- a/core/components/minishop2/elements/plugins/plugin.minishop2.php
+++ b/core/components/minishop2/elements/plugins/plugin.minishop2.php
@@ -24,6 +24,14 @@ switch ($modx->event->name) {
         }
         break;
 
+    case 'OnManagerPageBeforeRender':
+        /** @var miniShop2 $miniShop2 */
+        if ($miniShop2 = $modx->getService('miniShop2')) {
+            $modx->controller->addLexiconTopic('minishop2:default');
+            $modx->regClientStartupScript($miniShop2->config['jsUrl'] . 'mgr/misc/ms2.manager.js');
+        }
+        break;
+
     case 'OnLoadWebDocument':
         // Handle non-ajax requests
         if (!empty($_REQUEST['ms2_action'])) {


### PR DESCRIPTION
### Что оно делает?

1. При быстром создании товара/категории будет выбран шаблон из сис. настроек.
2. Если такие сис. настройки указаны у создаваемого контекста, то будет браться из соответствующего контекста.
3. Заголовок окон быстрого создания/обновления товара/категории будут соответствовать создаваемому типу.
4. При быстром создании категории содержимое будет из сис. настройки `ms2_category_content_default`. Если данная настройка указана у создаваемого контекста, то будет браться из него.

### Связанные проблема(ы)/PR(ы)

Closes #437, closes #82 
