### PR TITLE
Allow to disable default GROUP BY

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -84,7 +84,7 @@ foreach (array('where', 'leftJoin', 'innerJoin', 'select', 'groupby') as $v) {
             $tmp = json_decode($tmp, true);
         }
         if (is_array($tmp)) {
-            $$v = array_merge($$v, $tmp);
+            $$v = $tmp + $$v;
         }
     }
     unset($scriptProperties[$v]);


### PR DESCRIPTION
Allows to improve performance on large databases by using &groupby=`{"0":""}` in snippet call.
Thiis was tested without any msProductOption. Please, double check, if this can interfere with msProductOption implementation.
