### PR TITLE
Изменил порядок вкладок для категории

### DIFF
--- a/assets/components/minishop2/js/mgr/category/category.common.js
+++ b/assets/components/minishop2/js/mgr/category/category.common.js
@@ -35,8 +35,16 @@ Ext.extend(miniShop2.panel.Category, MODx.panel.Resource, {
                     }
                     else if (tab.id == 'modx-page-settings') {
                         tab.items = this.getCategorySettings(config);
+                        var pageSettingsTab = tab;
+                        item.items.splice(i2, 1);
+                    }
+                    else if (tab.id == 'modx-resource-access-permissions') {
+                        var accessPermissionsTab = tab;
+                        item.items.splice(i2, 1);
                     }
                 }
+                // Move the "Settings" and "Resource Groups" to the end of tabs
+                item.items.push(pageSettingsTab, accessPermissionsTab);
             }
             if (item.id != 'modx-resource-content') {
                 fields.push(item);

--- a/assets/components/minishop2/js/mgr/category/update.js
+++ b/assets/components/minishop2/js/mgr/category/update.js
@@ -131,15 +131,25 @@ Ext.extend(miniShop2.panel.UpdateCategory, miniShop2.panel.Category, {
                         continue;
                     }
                     var tab = item.items[i2];
-                    tabs.push(tab);
-                    // Additional tabs
-                    if (tab.id == 'modx-page-settings') {
-                        tab.items = this.addOptions(config, tab.items);
+                    if (tab.id != 'modx-page-settings' && tab.id != 'modx-resource-access-permissions') {
+                        tabs.push(tab);
+                    } else {
+                        // Get the "Settings" and "Resource Groups" tabs
+                        if (tab.id == 'modx-page-settings') {
+                            // Add "Product Options" inside the "Settings" tab
+                            tab.items = this.addOptions(config, tab.items);
+                            var pageSettingsTab = tab;
+                        }
+                        if (tab.id == 'modx-resource-access-permissions') {
+                            var accessPermissionsTab = tab;
+                        }
                     }
                 }
                 if (miniShop2.config['show_comments']) {
                     tabs.push(this.getComments(config));
                 }
+                // Move the "Settings" and "Resource Groups" to the end of tabs
+                tabs.push(pageSettingsTab, accessPermissionsTab);
                 item.items = tabs;
             }
             fields.push(item);


### PR DESCRIPTION
### Что оно делает?
Изменил порядок вкладок для категории в формах создания и обновления:

Было:
![cat_tabs_0](https://user-images.githubusercontent.com/12523676/91600040-f3413500-e96f-11ea-856a-6ca6b5205ab8.png)

**Стало:**
![cat_tabs](https://user-images.githubusercontent.com/12523676/91596272-7745ed80-e96d-11ea-83b0-a7a4d779f4f4.png)

### Зачем это нужно?
В нынешнем варианте miniShop2 у категории используемые вкладки разделены редко используемыми, еще и вкладка "Комментариев", если tickets установлен.

### Связанные проблема(ы)/PR(ы)
https://github.com/bezumkin/miniShop2/issues/456
https://github.com/bezumkin/miniShop2/pull/376

