### PR TITLE
Задал кодировку для корректного отображения сообщений сборщика

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -1,5 +1,7 @@
 <?php
 
+header('Content-Type: text/html; charset=utf-8');
+
 $mtime = microtime();
 $mtime = explode(' ', $mtime);
 $mtime = $mtime[1] + $mtime[0];


### PR DESCRIPTION
### Что оно делает?
Теперь русские символы нормально отображаются:

![p_encoding](https://user-images.githubusercontent.com/12523676/92248278-18362a80-eed1-11ea-9c1a-98e2b222e066.png)

### Связанные проблема(ы)/PR(ы)
https://github.com/bezumkin/miniShop2/issues/458
