### PR TITLE
Добавление возможности изменять опции товара в корзине

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -154,7 +154,7 @@ class miniShop2
                 $response = $this->cart->add(@$data['id'], @$data['count'], @$data['options']);
                 break;
             case 'cart/change':
-                $response = $this->cart->change(@$data['key'], @$data['count']);
+                $response = $this->cart->change(@$data['key'], @$data['count'], @$data['options']);
                 break;
             case 'cart/remove':
                 $response = $this->cart->remove(@$data['key']);


### PR DESCRIPTION
### Что оно делает?

Даёт возможность менять опции у товара который уже добавлен в корзину

### Зачем это нужно?

Нужно для того, чтобы не приходилось сначала удалять товар из корзины, затем по новой его добавлять с новой опцией.
