### PR TITLE
Fix PHP warning: count()

### DIFF
--- a/core/components/minishop2/processors/mgr/product/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/product/getlist.class.php
@@ -237,7 +237,8 @@ class msProductGetListProcessor extends modObjectGetListProcessor
             $array['preview_url'] = $this->modx->makeUrl($array['id'], $array['context_key']);
 
             // Options
-            if (is_countable($this->options)) {
+            if (is_array($this->options) && count($this->options)) {
+
                 /** @var msOption $option */
                 foreach ($this->options as $option) {
                     $array['options-'.$option->get('key')] = $option->getRowValue($array['id']);

--- a/core/components/minishop2/processors/mgr/product/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/product/getlist.class.php
@@ -237,7 +237,7 @@ class msProductGetListProcessor extends modObjectGetListProcessor
             $array['preview_url'] = $this->modx->makeUrl($array['id'], $array['context_key']);
 
             // Options
-            if (count($this->options)) {
+            if (is_countable($this->options)) {
                 /** @var msOption $option */
                 foreach ($this->options as $option) {
                     $array['options-'.$option->get('key')] = $option->getRowValue($array['id']);


### PR DESCRIPTION
### Что оно делает?

Исправляет `PHP warning: count()`

### Зачем это нужно?

Исправляет ошибку:
```php
(ERROR @ —//— core/components/minishop2/processors/mgr/product/getlist.class.php : 240) PHP warning: count(): Parameter must be an array or an object that implements Countable
```

### Связанные проблема(ы)/PR(ы)

NA
