### PR TITLE
Добавил прозрачность к выключенным строкам сетки

### DIFF
--- a/assets/components/minishop2/css/mgr/main.css
+++ b/assets/components/minishop2/css/mgr/main.css
@@ -27,7 +27,8 @@ a.link, a.ms2-link { color: #005580; }
 .minishop2-grid .x-grid-group-hd div.x-grid-group-title { padding: 8px 4px 12px 5px; }
 .minishop2-row-unpublished div,
 .minishop2-row-unpublished span,
-.minishop2-row-unpublished a {
+.minishop2-row-unpublished a,
+.minishop2-row-inactive div {
     font-style: italic;
     color: #aaa !important;
 }
@@ -38,12 +39,12 @@ a.link, a.ms2-link { color: #005580; }
     text-decoration: line-through !important;
 }
 .minishop2-row-unpublished img,
-.minishop2-row-deleted img {
+.minishop2-row-deleted img,
+.minishop2-row-inactive img,
+.minishop2-row-unpublished .minishop2-row-actions,
+.minishop2-row-deleted .minishop2-row-actions,
+.minishop2-row-inactive .minishop2-row-actions {
     opacity: .5;
-}
-.minishop2-row-inactive div {
-    font-style: italic;
-    color: #aaa !important;
 }
 .minishop2-row-required div {
     font-weight: bold;


### PR DESCRIPTION
### Что оно делает?
Изначально хотел поменять цвет для кнопок управления строкой в сетке, т.к. цвета не контрастны, что не удобно (см. https://github.com/bezumkin/miniShop2/issues/464).
Но кнопки выключения есть и в контекстном меню, а там это выглядеть будет неуместно.

В общем ограничился прозрачностью, этого достаточно, и теперь сразу понятно какая строка выключена.

![innactive-row](https://user-images.githubusercontent.com/12523676/99371598-2987b400-28d0-11eb-93a8-79b61c0bcee0.gif)

### Зачем это нужно?
Улучшение UI/UX

### Связанные проблема(ы)/PR(ы)
https://github.com/bezumkin/miniShop2/issues/464
