### PR TITLE
add order product's options interface

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -240,6 +240,11 @@ $tmp = array(
         'value' => 'product_pagetitle,product_article,weight,price,count,cost',
         'area' => 'ms2_order',
     ),
+    'ms_order_product_options' => array(
+        'xtype' => 'textarea',
+        'value' => 'size,color',
+        'area' => 'ms2_order',
+    ),
 
     'ms2_order_handler_class' => array(
         'value' => 'msOrderHandler',

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -240,7 +240,7 @@ $tmp = array(
         'value' => 'product_pagetitle,product_article,weight,price,count,cost',
         'area' => 'ms2_order',
     ),
-    'ms_order_product_options' => array(
+    'ms2_order_product_options' => array(
         'xtype' => 'textarea',
         'value' => 'size,color',
         'area' => 'ms2_order',

--- a/assets/components/minishop2/js/mgr/orders/orders.window.product.js
+++ b/assets/components/minishop2/js/mgr/orders/orders.window.product.js
@@ -13,7 +13,8 @@ miniShop2.window.OrderProduct = function (config) {
 };
 Ext.extend(miniShop2.window.OrderProduct, miniShop2.window.Default, {
 
-    getFields: function () {
+    getFields: function (config) {
+        const options = this.getOptionsFields(config);
         return [
             {xtype: 'hidden', name: 'id'},
             {xtype: 'hidden', name: 'order_id'},
@@ -74,9 +75,17 @@ Ext.extend(miniShop2.window.OrderProduct, miniShop2.window.Default, {
                         name: 'weight',
                         anchor: '100%'
                     }]
-                }]
+                }, ]
             },
-            {xtype: 'textarea', fieldLabel: _('ms2_product_options'), name: 'options', height: 100, anchor: '100%'}
+            {
+                xtype: 'textarea',
+                fieldLabel: _('ms2_product_options'),
+                name: 'options',
+                height: 100,
+                anchor: '100%'
+            },
+
+            options
         ];
     },
 
@@ -90,5 +99,193 @@ Ext.extend(miniShop2.window.OrderProduct, miniShop2.window.Default, {
         }];
     },
 
+    getOptionsFields: function (config) {
+        const items = [];
+        if(config.record.options) {
+            const options = JSON.parse(config.record.options);
+            let i = 0;
+            for(let key in options) {
+                if(!Array.isArray(options[key])  && miniShop2.config['order_product_options_fields'].includes(key)){
+                    items.push(
+                        {
+                            columnWidth: 0.5,
+                            layout: 'form',
+                            defaults: {msgTarget: 'under'},
+                            border: false,
+                            items: [{
+                                xtype: 'textfield',
+                                fieldLabel: _('ms2_frontend_' + key) || key,
+                                name: 'option-' + key,
+                                anchor: '100%',
+                            }]
+                        }
+                    );
+
+                    i++;
+                }
+            }
+        }
+
+
+        return {
+            xtype: 'fieldset',
+            title: _('ms2_product_options'),
+            layout: 'column',
+            style: 'padding:15px 5px;text-align:center;',
+            defaults: {msgTarget: 'under', border: false},
+            items: [{
+                columnWidth: 1,
+                layout: 'form',
+                items: items
+            }]
+        };
+    },
+});
+Ext.reg('minishop2-window-orderproduct-update', miniShop2.window.OrderProduct);miniShop2.window.OrderProduct = function (config) {
+    config = config || {};
+
+    Ext.applyIf(config, {
+        title: _('ms2_menu_update'),
+        width: 600,
+        baseParams: {
+            action: config.action || 'mgr/orders/product/update',
+        },
+        modal: true,
+    });
+    miniShop2.window.OrderProduct.superclass.constructor.call(this, config);
+};
+
+
+
+Ext.extend(miniShop2.window.OrderProduct, miniShop2.window.Default, {
+
+    getFields: function (config) {
+
+        const options = this.getOptionsFields(config);
+        return [
+            {xtype: 'hidden', name: 'id'},
+            {xtype: 'hidden', name: 'order_id'},
+            {
+                layout: 'column',
+                border: false,
+                anchor: '100%',
+                items: [{
+                    columnWidth: .3,
+                    layout: 'form',
+                    defaults: {msgTarget: 'under'},
+                    border: false,
+                    items: [{
+                        xtype: 'numberfield',
+                        fieldLabel: _('ms2_product_count'),
+                        name: 'count',
+                        anchor: '100%',
+                        allowNegative: false,
+                        allowBlank: false
+                    }]
+                }, {
+                    columnWidth: .7,
+                    layout: 'form',
+                    defaults: {msgTarget: 'under'},
+                    border: false,
+                    items: [{
+                        xtype: 'textfield',
+                        fieldLabel: _('ms2_name'),
+                        name: 'name',
+                        anchor: '100%'
+                    }]
+                }]
+            }, {
+                layout: 'column',
+                border: false,
+                anchor: '100%',
+                items: [{
+                    columnWidth: .5,
+                    layout: 'form',
+                    defaults: {msgTarget: 'under'},
+                    border: false,
+                    items: [{
+                        xtype: 'numberfield',
+                        decimalPrecision: 2,
+                        fieldLabel: _('ms2_product_price'),
+                        name: 'price',
+                        anchor: '100%'
+                    }]
+                }, {
+                    columnWidth: .5,
+                    layout: 'form',
+                    defaults: {msgTarget: 'under'},
+                    border: false,
+                    items: [{
+                        xtype: 'numberfield',
+                        decimalPrecision: 3,
+                        fieldLabel: _('ms2_product_weight'),
+                        name: 'weight',
+                        anchor: '100%'
+                    }]
+                }, ]
+            },
+            {
+                xtype: 'textarea',
+                fieldLabel: _('ms2_product_options'),
+                name: 'options',
+                height: 100,
+                anchor: '100%'
+            },
+
+            options
+        ];
+    },
+
+    getKeys: function () {
+        return [{
+            key: Ext.EventObject.ENTER,
+            shift: true,
+            fn: function () {
+                this.submit()
+            }, scope: this
+        }];
+    },
+
+    getOptionsFields: function (config) {
+        const items = [];
+        if(config.record.options) {
+            const options = JSON.parse(config.record.options);
+            let i = 0;
+            for(let key in options) {
+                if(!Array.isArray(options[key])  && miniShop2.config['order_product_options_fields'].includes(key)){
+                    items.push(
+                        {
+                            columnWidth: 0.5,
+                            layout: 'form',
+                            defaults: {msgTarget: 'under'},
+                            border: false,
+                            items: [{
+                                xtype: 'textfield',
+                                fieldLabel: _('ms2_frontend_' + key) || key,
+                                name: 'option-' + key,
+                                anchor: '100%',
+                            }]
+                        }
+                    );
+
+                    i++;
+                }
+            }
+        }
+
+
+        return {
+            xtype: 'fieldset',
+            title: _('ms2_product_options'),
+            layout: 'column',
+            style: 'padding:15px 5px;text-align:center;',
+            defaults: {msgTarget: 'under', border: false},
+            items: [{
+                columnWidth: 1,
+                layout: 'form',
+                items: items
+            }]
+        };
+    },
 });
 Ext.reg('minishop2-window-orderproduct-update', miniShop2.window.OrderProduct);

--- a/core/components/minishop2/controllers/mgr/orders.class.php
+++ b/core/components/minishop2/controllers/mgr/orders.class.php
@@ -61,7 +61,7 @@ class Minishop2MgrOrdersManagerController extends msManagerController
         $product_fields = array_values(array_unique(array_merge($product_fields, array(
             'id', 'product_id', 'name', 'actions'
         ))));
-        $product_options = array_map('trim', explode(',', $this->getOption('ms_order_product_options')));
+        $product_options = array_map('trim', explode(',', $this->getOption('ms2_order_product_options')));
 
         $config = $this->miniShop2->config;
         $config['order_grid_fields'] = $grid_fields;

--- a/core/components/minishop2/controllers/mgr/orders.class.php
+++ b/core/components/minishop2/controllers/mgr/orders.class.php
@@ -61,11 +61,13 @@ class Minishop2MgrOrdersManagerController extends msManagerController
         $product_fields = array_values(array_unique(array_merge($product_fields, array(
             'id', 'product_id', 'name', 'actions'
         ))));
+        $product_options = array_map('trim', explode(',', $this->getOption('ms_order_product_options')));
 
         $config = $this->miniShop2->config;
         $config['order_grid_fields'] = $grid_fields;
         $config['order_address_fields'] = $address_fields;
         $config['order_product_fields'] = $product_fields;
+        $config['order_product_options_fields'] = $product_options;
         $this->addHtml('
             <script type="text/javascript">
                 miniShop2.config = ' . json_encode($config) . ';

--- a/core/components/minishop2/lexicon/ru/setting.inc.php
+++ b/core/components/minishop2/lexicon/ru/setting.inc.php
@@ -126,6 +126,8 @@ $_lang['setting_ms2_order_address_fields'] = 'Поля адреса достав
 $_lang['setting_ms2_order_address_fields_desc'] = 'Список полей доставки, которые будут показаны на третьей вкладке карточки заказа. Доступны: "receiver,phone,index,country,region,metro,building,city,street,room". Если параметр пуст, вкладка будет скрыта.';
 $_lang['setting_ms2_order_product_fields'] = 'Поля таблицы покупок';
 $_lang['setting_ms2_order_product_fields_desc'] = 'Список полей таблицы заказанных товаров. Доступны: "count,price,weight,cost,options". Поля товара указываются с префиксом "product_", например "product_pagetitle,product_article". Дополнительно можно указывать значения из поля options с префиксом "option_", например: "option_color,option_size".';
+$_lang['setting_ms2_order_product_options'] = 'Поля опций продукта в заказе';
+$_lang['setting_ms2_order_product_options_desc'] = 'Перечень редактируемых опций товара в окне заказа. По умолчанию color, size';
 
 $_lang['ms2_source_thumbnails_desc'] = 'Закодированный в JSON массив с параметрами генерации уменьшенных копий изображений.';
 $_lang['ms2_source_maxUploadWidth_desc'] = 'Максимальная ширина изображения для загрузки. Всё, что больше, будет ужато до этого значения.';

--- a/core/components/minishop2/processors/mgr/orders/product/update.class.php
+++ b/core/components/minishop2/processors/mgr/orders/product/update.class.php
@@ -36,10 +36,19 @@ class msOrderProductUpdateProcessor extends modObjectUpdateProcessor
         }
 
         if ($options = $this->getProperty('options')) {
+
+            if (is_array($options)) {
+                $options = json_encode($options, JSON_UNESCAPED_UNICODE);
+            }
+
             $tmp = json_decode($options, true);
+
+            $buildedOptions = $this->buildOptions();
+
             if (!is_array($tmp)) {
                 $this->modx->error->addField('options', $this->modx->lexicon('ms2_err_json'));
             } else {
+                $tmp = array_merge($tmp, $buildedOptions);
                 $this->setProperty('options', $tmp);
             }
         }
@@ -70,6 +79,18 @@ class msOrderProductUpdateProcessor extends modObjectUpdateProcessor
         if ($this->order = $this->modx->getObject('msOrder', $this->order->id, false)) {
             $this->order->updateProducts();
         }
+    }
+
+    private function buildOptions()
+    {
+        $options = [];
+        foreach ($this->getProperties() as $key => $value) {
+            $tmp = explode('-', $key);
+            if (is_array($tmp) && count($tmp) === 2 && $tmp[0] === 'option') {
+                $options[$tmp[1]] = $value;
+            }
+        }
+        return $options;
     }
 
 }


### PR DESCRIPTION
**Какую решал проблему**
В окне заказа каждый продукт содержит текстовое окно с JSON набором опций
[https://prnt.sc/vr2edz](https://prnt.sc/vr2edz)
Задача сделать удобный интерфейс редактирования подобных опций товара.

Реализован [вот такой интерфейс](https://prnt.sc/vr2gu4)

Также реализована системная настройка  **ms_order_product_options**
Она регулирует какие именно поля выводить для редактирования в новом интерфейсе. 

**Шаги для проверки.** 

- Создать заказ с опциями у товара.   
- Убедиться что ключи опций добавлены в системную настройку.  
- Проверить успешный вывод полей для редактирования. 
- Проверить сохранение обновленных данных
- Убрать часть полей из системной настройки, Убедиться что они исчезли и из интерфейса
