### PR TITLE
fix logic for free delivery calculation

### DIFF
--- a/core/components/minishop2/model/minishop2/msdeliveryhandler.class.php
+++ b/core/components/minishop2/model/minishop2/msdeliveryhandler.class.php
@@ -86,11 +86,12 @@ class msDeliveryHandler implements msDeliveryInterface
             $add_price = str_replace('%', '', $add_price);
             $add_price = $cost / 100 * $add_price;
         }
-        
-        $free_delivery_amount = $delivery->get('free_delivery_amount'); 
-        if($free_delivery_amount > 0 && $free_delivery_amount < $cost) {
+
+        $cart = $this->ms2->cart->status();
+        $free_delivery_amount = $delivery->get('free_delivery_amount');
+        if ($free_delivery_amount > 0 && $free_delivery_amount <= $cart['total_cost']) {
             $add_price = 0;
-        } 
+        }
 
         $cost += $add_price;
 


### PR DESCRIPTION
### Что оно делает?

Исправлена логика работы PR от webmind (расчет бесплатной доставки)

### Было

Сравнение бесплатной доставки с входящим параметром $cost который иногда равен нулю и не отражает реальной стоимости корзины

### Стало
В метод getCost класса msDeliveryHandler добавлена постоянная стоимость корзины ms2->cart->status(), и сравнение бесплатной суммы доставки сделано с суммой корзины, которая всегда постоянна и не равна нулю.
