### PR TITLE
Модификатор вместо функции

### DIFF
--- a/core/components/minishop2/elements/chunks/chunk.ms_cart.tpl
+++ b/core/components/minishop2/elements/chunks/chunk.ms_cart.tpl
@@ -1,5 +1,5 @@
 <div id="msCart">
-    {if !count($products)}
+    {if $products | length == 0}
         <div class="alert alert-warning">
             {'ms2_cart_is_empty' | lexicon}
         </div>


### PR DESCRIPTION


### Что оно делает?

При пустом массиве $products функция count() сыплет в журнал ошибками вида
`PHP warning: count(): Parameter must be an array or an object that implements Countable`
