### PR TITLE
Set checkbox value

### DIFF
--- a/core/components/minishop2/processors/mgr/settings/option/types/checkbox.class.php
+++ b/core/components/minishop2/processors/mgr/settings/option/types/checkbox.class.php
@@ -11,9 +11,10 @@ class msCheckboxType extends msOptionType
     public function getField($field)
     {
         return "{
-            xtype:'xcheckbox',
+            xtype: 'xcheckbox',
             boxLabel: '" . $field['caption'] . "',
-            checked: ".(filter_var($field['value'], FILTER_VALIDATE_BOOLEAN) ? 1 : 0).",
+            checked: " . (filter_var($field['value'], FILTER_VALIDATE_BOOLEAN) ? 1 : 0) . ",
+            value: " . (!empty($field['value']) ? 1 : 0) . ",
             convertValue: function (v) {
                 return (
                     v === '1' || v === true || v === 'true' ||


### PR DESCRIPTION
### Что оно делает?

Переопределение логики работы опции-чекбокса в админпанели. Передача значения 1|0 при выбранном или снятом чекбоксе.

### Зачем это нужно?

Состояние чекбокса не отражает значение в БД.
Опция может выглядеть как "включенная": чекбокс установлен (checked) при загрузке страницы админки, но в БД значение чекбокса хранится как пустое. Однако на самом деле она выключена. При сохранении товара с якобы "включенной" опцией могут возникать неочевидные проблемы:

1. При добавлении свойства для категории товаров без указания значения по умолчанию, опция выглядит включенной для всех товаров в категории, что на самом деле не верно.
2. При сортировке в админке порядка свойств автоматически "включаются" свойства - добавляется пустая запись в БД.

