### PR TITLE
Дополнительный тест перед добавлением  поля free_delivery_amount

### DIFF
--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -48,8 +48,19 @@ if ($transport->xpdo) {
 
             $manager->addField('msOrderProduct', 'name');
 
+            //fix error when modx not updated object map
+            if (!array_key_exists('free_delivery_amount', $modx->map['msDelivery']['fields'])) {
+                $modx->map['msDelivery']['fields']['free_delivery_amount'] = array(
+                    'dbtype' => 'decimal',
+                    'precision' => '12,2',
+                    'phptype' => 'float',
+                    'null' => true,
+                    'default' => 0.0,
+                );
+            }
+
             $manager->addField('msDelivery', 'free_delivery_amount');
-            
+
             $manager->alterField('msDelivery', 'price');
             $manager->addField('msPayment', 'price', array('after' => 'description'));
 


### PR DESCRIPTION
### Что оно делает?

Дополнительная проверка в резолвере таблиц на наличие в карте объекта msDelivery добавленного поля free_delivery_price

### Зачем это нужно?

Иногда при обновлении ms 2.6 на  2.7  в карту объекта не попадает информация о новом поле. 
Вследствие чего при работе резолвера новое поле в базу не добавляется.  Резолвер просто не понимает какие метаданные будут у поля.  

Из-за недобавленного поля получаем серверную ошибку в админке при попытке открытия настроек доставки.

### Связанные проблема(ы)/PR(ы)

Проблему обсуждали, issue  не нашел
