### PR TITLE
Support of content blocks editor in products and categories

### DIFF
--- a/assets/components/minishop2/js/mgr/category/category.common.js
+++ b/assets/components/minishop2/js/mgr/category/category.common.js
@@ -65,11 +65,12 @@ Ext.extend(miniShop2.panel.Category, MODx.panel.Resource, {
             }
             var item = originals[i];
 
-            if (item.id == 'ta') {
+            if (item.id === 'ta') {
                 item.hideLabel = false;
                 item.fieldLabel = _('content');
+                item.itemCls = 'contentblocks_replacement';
                 item.description = '<b>[[*content]]</b>';
-                if (MODx.config['ms2_category_content_default'] && config['mode'] == 'create') {
+                if (MODx.config['ms2_category_content_default'] && config['mode'] === 'create') {
                     item.value = MODx.config['ms2_category_content_default'];
                 }
                 item.hidden = miniShop2.config.isHideContent;

--- a/assets/components/minishop2/js/mgr/product/product.common.js
+++ b/assets/components/minishop2/js/mgr/product/product.common.js
@@ -281,9 +281,10 @@ Ext.extend(miniShop2.panel.Product, MODx.panel.Resource, {
             }
             var item = originals[i];
 
-            if (item.id == 'ta') {
+            if (item.id === 'ta') {
                 item.hideLabel = false;
                 item.fieldLabel = _('content');
+                item.itemCls = 'contentblocks_replacement';
                 item.description = '<b>[[*content]]</b>';
                 item.hidden = miniShop2.config.isHideContent;
             }


### PR DESCRIPTION
### Что оно делает?

Добавляет возможность заменить поле Содержимое редактором блоков [ContentBlocks](https://modmore.com/contentblocks/).

### Зачем это нужно?

Бывают случаи, когда редактор блоков мог бы пригодиться, когда страница товара большая и складывается из блоков. Для этих целей удобно применять ContentBlocks (цена оправдана, если решается задача клиента).

### Как протестировать?

Для тестирования нужно использовать сайт на домене, который удовлетворяет критериям, описанным на [этой странице](https://support.modmore.com/article/130-what-domains-qualify-for-a-free-development-license).

Затем нужно завести аккаунт на modmore.com и создать там ключ, который указать при добавлении провайдера. После установить CB через менеджер пакетов.

Для того, чтобы CB стал загружаться на страницах каталога (категория и товар), нужно в системной настройке `contentblocks.accepted_resource_types` дописать соответствующие class_key: `,msProduct,msCategory`.

Открыть страницу товара и/или категории и удостовериться, что поле Содержимое заменилось на ContentBlocks.

### Связанные проблема(ы)/PR(ы)

[Документация](https://docs.modmore.com/en/ContentBlocks/v1.x/Custom_Resources.html) по интеграции CB для кастомных типов ресурсов. 
[Пример](https://github.com/modxcms/Articles/pull/87) такой интеграции для Articles.
