### PR TITLE
fix error with Recoverable error

### DIFF
--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -645,7 +645,7 @@ class msProductData extends xPDOSimpleObject
         );
         $response = $miniShop2->invokeEvent('msOnGetProductFields', $params);
         if ($response['success']) {
-            $data = array_merge($data, $response['data']);
+            $data = array_merge($data, $response['data']['data']);
         }
 
         return $data;


### PR DESCRIPTION
### Что оно делает?

Поправил слияние данных с результатом работы события msOnGetProductFields

### Зачем это нужно?

Recoverable error: Object of class msProductData_mysql could not be converted to string

### Связанные проблема(ы)/PR(ы)

https://modx.pro/help/21224
