### PR TITLE
refactoring filter_options

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -96,16 +96,29 @@ $joinedOptions = array();
 if (!empty($scriptProperties['optionFilters'])) {
     $filters = json_decode($scriptProperties['optionFilters'], true);
     foreach ($filters as $key => $value) {
+        $components = explode(':', $key, 2);
+
+        if (count($components) === 2) {
+            if (in_array(strtolower($components[0]), ['or', 'and'])) {
+                [$operator, $key] = $components;
+            }
+        }
+
         $option = preg_replace('#\:.*#', '', $key);
         $key = str_replace($option, $option . '.value', $key);
+
         if (!in_array($option, $joinedOptions)) {
             $leftJoin[$option] = array(
                 'class' => 'msProductOption',
                 'on' => "`{$option}`.product_id = Data.id AND `{$option}`.key = '{$option}'",
             );
             $joinedOptions[] = $option;
-            $where[$key] = $value;
         }
+
+        $index = isset($operator) && in_array(strtolower($operator), ['or', 'and'], true)
+            ? sprintf('%s:%s', strtoupper($operator), $key)
+            : $key;
+        $where[$index] = $value;
     }
 }
 


### PR DESCRIPTION
### Что оно делает?

Обновлен сниппет msProducts.
Добавлена поддержка операторов OR, AND в параметре optionFilters

### Зачем это нужно?

[Issue #415
](https://github.com/Ibochkarev/miniShop2/issues/415)

### Как тестировать

-  Создать пару опций.  Например width, height
- Заполнить несколько товаров опциями
- В шаблоне вывести примерно такой код  
``` php
        [[!msProducts?
            &parents=`0`
            &optionFilters=`{"width":"300", "OR:height:>=":"200"}`
        ]]
```

- Тестировать правильную выборку по 5 вариациям


1. ```&optionFilters=`{"width":"300"}``` 
2. ```&optionFilters=`{"width:>=":"300"}``` 
3. ```&optionFilters=`{"width":"300", "height":"200"}```  Аналог логического оператора AND
4. ```&optionFilters=`{"width":"300", "OR:height":"200"}```  
5. ```&optionFilters=`{"width":"300", "OR:height:>=":"200"}```
