### PR TITLE
Отображение значения опции товара на странице категории товаров #535

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ config.core.php
 sftp-config.json
 .idea
 .gitignore
+.DS_Store
 tests/properties.inc.php

--- a/core/components/minishop2/processors/mgr/product/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/product/getlist.class.php
@@ -237,8 +237,8 @@ class msProductGetListProcessor extends modObjectGetListProcessor
             $array['preview_url'] = $this->modx->makeUrl($array['id'], $array['context_key']);
 
             // Options
-            if (is_array($this->options) && count($this->options)) {
-
+            $this->options->rewind();
+            if ($this->options->valid()) {
                 /** @var msOption $option */
                 foreach ($this->options as $option) {
                     $array['options-'.$option->get('key')] = $option->getRowValue($array['id']);


### PR DESCRIPTION
### Что оно делает?

Проверка объекта на валидность

### Зачем это нужно?

Вывод значений опций товара на странице категории товаров 

### Связанные проблема(ы)/PR(ы)

#535 
