### PR TITLE
Fix for "bad fix" of Recoverable error

### DIFF
--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -646,7 +646,6 @@ class msProductData extends xPDOSimpleObject
         $response = $miniShop2->invokeEvent('msOnGetProductFields', $params);
         if ($response['success']) {
             unset($response['data']['product']);
-            unset($response['data']['data']);
             $data = array_merge($data, $response['data']);
         }
 

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -645,7 +645,9 @@ class msProductData extends xPDOSimpleObject
         );
         $response = $miniShop2->invokeEvent('msOnGetProductFields', $params);
         if ($response['success']) {
-            $data = array_merge($data, $response['data']['data']);
+            unset($response['data']['product']);
+            unset($response['data']['data']);
+            $data = array_merge($data, $response['data']);
         }
 
         return $data;


### PR DESCRIPTION
### Что оно делает?

Исправляет ошибку https://modx.pro/help/21224 не ломая ничего взамен.

### Зачем это нужно?

После принятия коммита https://github.com/Ibochkarev/miniShop2/pull/532 поломалось событие `msOnGetProductFields`. Для проверки того что изменений не происходит достаточно создать плагин меняющий поля товара через событие:

```php
<?php
switch($modx->event->name) { 
    case 'msOnGetProductFields':
        $returned_values = & $modx->event->returnedValues;
        $values =  $modx->event->params['data'];
          
        $returned_values['price'] = $values['price'] * 2;
        $returned_values['old_price'] = $values['price'] * 3;
        $returned_values['article'] = 'custom_article';
        $returned_values['weight'] = 222;
    	break;
}
```

После внесения изменений, отправленных в моём коммите - ошибка с `Recoverable error` не появляется, и при этом ничего не ломается.

### Связанные проблема(ы)/PR(ы)

https://github.com/Ibochkarev/miniShop2/pull/532
