### PR TITLE
Удалены ссылки на объекты

### DIFF
--- a/_build/resolvers/resolve.chunks.php
+++ b/_build/resolvers/resolve.chunks.php
@@ -4,7 +4,7 @@ if (!$transport->xpdo || !($transport instanceof xPDOTransport)) {
     return false;
 }
 /** @var modX $modx */
-$modx =& $transport->xpdo;
+$modx = $transport->xpdo;
 /** @var array $options */
 switch ($options[xPDOTransport::PACKAGE_ACTION]) {
     case xPDOTransport::ACTION_INSTALL:

--- a/_build/resolvers/resolve.extension.php
+++ b/_build/resolvers/resolve.extension.php
@@ -4,7 +4,7 @@
 /** @var array $options */
 /** @var modX $modx */
 if ($transport->xpdo) {
-    $modx =& $transport->xpdo;
+    $modx = $transport->xpdo;
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
         case xPDOTransport::ACTION_UPGRADE:

--- a/_build/resolvers/resolve.policy.php
+++ b/_build/resolvers/resolve.policy.php
@@ -4,7 +4,7 @@
 /** @var array $options */
 /** @var modX $modx */
 if ($transport->xpdo) {
-    $modx =& $transport->xpdo;
+    $modx = $transport->xpdo;
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
         case xPDOTransport::ACTION_UPGRADE:

--- a/_build/resolvers/resolve.settings.php
+++ b/_build/resolvers/resolve.settings.php
@@ -4,7 +4,7 @@
 /** @var array $options */
 /** @var modX $modx */
 if ($transport->xpdo) {
-    $modx =& $transport->xpdo;
+    $modx = $transport->xpdo;
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
         case xPDOTransport::ACTION_UPGRADE:

--- a/_build/resolvers/resolve.setup.php
+++ b/_build/resolvers/resolve.setup.php
@@ -5,7 +5,7 @@ if (!$transport->xpdo || !($transport instanceof xPDOTransport)) {
 }
 
 /** @var modX $modx */
-$modx =& $transport->xpdo;
+$modx = $transport->xpdo;
 $packages = array(
     'pdoTools' => array(
         'version' => '2.12.0-pl',

--- a/_build/resolvers/resolve.sources.php
+++ b/_build/resolvers/resolve.sources.php
@@ -4,7 +4,7 @@
 /** @var array $options */
 /** @var modX $modx */
 if ($transport->xpdo) {
-    $modx =& $transport->xpdo;
+    $modx = $transport->xpdo;
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
         case xPDOTransport::ACTION_UPGRADE:

--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -4,7 +4,7 @@
 /** @var array $options */
 /** @var modX $modx */
 if ($transport->xpdo) {
-    $modx =& $transport->xpdo;
+    $modx = $transport->xpdo;
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
         case xPDOTransport::ACTION_UPGRADE:

--- a/_build/resolvers/resolve.upgrade.php
+++ b/_build/resolvers/resolve.upgrade.php
@@ -4,7 +4,7 @@
 /** @var array $options */
 /** @var modX $modx */
 if ($transport->xpdo) {
-    $modx =& $transport->xpdo;
+    $modx = $transport->xpdo;
     switch ($options[xPDOTransport::PACKAGE_ACTION]) {
         case xPDOTransport::ACTION_INSTALL:
             break;

--- a/core/components/minishop2/controllers/category/create.class.php
+++ b/core/components/minishop2/controllers/category/create.class.php
@@ -94,6 +94,6 @@ class msCategoryCreateManagerController extends msResourceCreateController
 
         // load RTE
         $this->loadRichTextEditor();
-        $this->modx->invokeEvent('msOnManagerCustomCssJs', array('controller' => &$this, 'page' => 'category_create'));
+        $this->modx->invokeEvent('msOnManagerCustomCssJs', array('controller' => $this, 'page' => 'category_create'));
     }
 }

--- a/core/components/minishop2/controllers/category/update.class.php
+++ b/core/components/minishop2/controllers/category/update.class.php
@@ -142,7 +142,7 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
 
         // load RTE
         $this->loadRichTextEditor();
-        $this->modx->invokeEvent('msOnManagerCustomCssJs', array('controller' => &$this, 'page' => 'category_update'));
+        $this->modx->invokeEvent('msOnManagerCustomCssJs', array('controller' => $this, 'page' => 'category_update'));
         $this->loadPlugins();
 
         // Load Tickets

--- a/core/components/minishop2/controllers/mgr/orders.class.php
+++ b/core/components/minishop2/controllers/mgr/orders.class.php
@@ -81,7 +81,7 @@ class Minishop2MgrOrdersManagerController extends msManagerController
         );
 
         $this->modx->invokeEvent('msOnManagerCustomCssJs', array(
-            'controller' => &$this,
+            'controller' => $this,
             'page' => 'orders',
         ));
     }

--- a/core/components/minishop2/controllers/mgr/settings.class.php
+++ b/core/components/minishop2/controllers/mgr/settings.class.php
@@ -82,7 +82,7 @@ class Minishop2MgrSettingsManagerController extends msManagerController
         </script>');
 
         $this->modx->invokeEvent('msOnManagerCustomCssJs', array(
-            'controller' => &$this,
+            'controller' => $this,
             'page' => 'settings',
         ));
     }

--- a/core/components/minishop2/controllers/product/update.class.php
+++ b/core/components/minishop2/controllers/product/update.class.php
@@ -165,7 +165,7 @@ class msProductUpdateManagerController extends msResourceUpdateController
 
         // load RTE
         $this->loadRichTextEditor();
-        $this->modx->invokeEvent('msOnManagerCustomCssJs', array('controller' => &$this, 'page' => 'product_update'));
+        $this->modx->invokeEvent('msOnManagerCustomCssJs', array('controller' => $this, 'page' => 'product_update'));
         $this->loadPlugins();
     }
 

--- a/core/components/minishop2/elements/snippets/snippet.ms_cart.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_cart.php
@@ -138,7 +138,7 @@ foreach ($cart as $key => $entry) {
     }
 
     // Add option values
-    $options = $modx->call('msProductData', 'loadOptions', array(&$modx, $product['id']));
+    $options = $modx->call('msProductData', 'loadOptions', array($modx, $product['id']));
     $products[] = array_merge($product, $options);
 
     // Count total

--- a/core/components/minishop2/elements/snippets/snippet.ms_get_order.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_get_order.php
@@ -141,7 +141,7 @@ foreach ($rows as $product) {
     }
 
     // Add option values
-    $options = $modx->call('msProductData', 'loadOptions', array(&$modx, $product['id']));
+    $options = $modx->call('msProductData', 'loadOptions', array($modx, $product['id']));
     $products[] = array_merge($product, $options);
 
     // Count total

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -223,7 +223,7 @@ if (!empty($rows) && is_array($rows)) {
         $row['idx'] = $pdoFetch->idx++;
 
         $opt_time_start = microtime(true);
-        $options = $modx->call('msProductData', 'loadOptions', array(&$modx, $row['id']));
+        $options = $modx->call('msProductData', 'loadOptions', array($modx, $row['id']));
         $row = array_merge($row, $options);
         $opt_time += microtime(true) - $opt_time_start;
 

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -25,9 +25,9 @@ class miniShop2
     * @param modX $modx
     * @param array $config
     */
-    function __construct(modX &$modx, array $config = array())
+    function __construct(modX $modx, array $config = array())
     {
-        $this->modx =& $modx;
+        $this->modx = $modx;
 
         $corePath = $this->modx->getOption('minishop2.core_path', $config, MODX_CORE_PATH . 'components/minishop2/');
         $assetsPath = $this->modx->getOption('minishop2.assets_path', $config,
@@ -637,7 +637,7 @@ class miniShop2
 
         $response = $this->invokeEvent('msOnBeforeGetOrderCustomer', array(
             'order' => $this->order,
-            'customer' => &$customer,
+            'customer' => $customer,
         ));
         if (!$response['success']) {
             return $response['message'];
@@ -706,7 +706,7 @@ class miniShop2
 
         $response = $this->invokeEvent('msOnGetOrderCustomer', array(
             'order' => $this->order,
-            'customer' => &$customer,
+            'customer' => $customer,
         ));
         if (!$response['success']) {
             return $response['message'];

--- a/core/components/minishop2/model/minishop2/mscarthandler.class.php
+++ b/core/components/minishop2/model/minishop2/mscarthandler.class.php
@@ -104,10 +104,10 @@ class msCartHandler implements msCartInterface
     * @param miniShop2 $ms2
     * @param array $config
     */
-    function __construct(miniShop2 &$ms2, array $config = array())
+    function __construct(miniShop2 $ms2, array $config = array())
     {
-        $this->ms2 = &$ms2;
-        $this->modx = &$ms2->modx;
+        $this->ms2 = $ms2;
+        $this->modx = $ms2->modx;
 
         $this->config = array_merge(array(
             'cart' => & $_SESSION['minishop2']['cart'],

--- a/core/components/minishop2/model/minishop2/msoption.class.php
+++ b/core/components/minishop2/model/minishop2/msoption.class.php
@@ -20,8 +20,8 @@ abstract class msOptionType
     */
     public function __construct(msOption $option, array $config = array())
     {
-        $this->option =& $option;
-        $this->xpdo =& $option->xpdo;
+        $this->option = $option;
+        $this->xpdo = $option->xpdo;
         $this->config = array_merge($this->config, $config);
     }
 

--- a/core/components/minishop2/model/minishop2/msorder.class.php
+++ b/core/components/minishop2/model/minishop2/msorder.class.php
@@ -39,8 +39,8 @@ class msOrder extends xPDOSimpleObject
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('msOnBeforeSaveOrder', array(
                 'mode' => $isNew ? modSystemEvent::MODE_NEW : modSystemEvent::MODE_UPD,
-                'object' => &$this,
-                'msOrder' => &$this,
+                'object' => $this,
+                'msOrder' => $this,
                 'cacheFlag' => $cacheFlag,
             ));
         }
@@ -50,8 +50,8 @@ class msOrder extends xPDOSimpleObject
         if ($saved && $this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('msOnSaveOrder', array(
                 'mode' => $isNew ? modSystemEvent::MODE_NEW : modSystemEvent::MODE_UPD,
-                'object' => &$this,
-                'msOrder' => &$this,
+                'object' => $this,
+                'msOrder' => $this,
                 'cacheFlag' => $cacheFlag,
             ));
         }
@@ -64,8 +64,8 @@ class msOrder extends xPDOSimpleObject
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('msOnBeforeRemoveOrder', array(
                 'id' => parent::get('id'),
-                'object' => &$this,
-                'msOrder' => &$this,
+                'object' => $this,
+                'msOrder' => $this,
                 'ancestors' => $ancestors,
             ));
         }
@@ -75,8 +75,8 @@ class msOrder extends xPDOSimpleObject
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('msOnRemoveOrder', array(
                 'id' => parent::get('id'),
-                'object' => &$this,
-                'msOrder' => &$this,
+                'object' => $this,
+                'msOrder' => $this,
                 'ancestors' => $ancestors,
             ));
         }

--- a/core/components/minishop2/model/minishop2/msorderhandler.class.php
+++ b/core/components/minishop2/model/minishop2/msorderhandler.class.php
@@ -105,7 +105,7 @@ class msOrderHandler implements msOrderInterface
     * @param miniShop2 $ms2
     * @param array $config
     */
-    function __construct(miniShop2 &$ms2, array $config = array())
+    function __construct(miniShop2 $ms2, array $config = array())
     {
         $this->ms2 = $ms2;
         $this->modx = $ms2->modx;

--- a/core/components/minishop2/model/minishop2/msproduct.class.php
+++ b/core/components/minishop2/model/minishop2/msproduct.class.php
@@ -266,7 +266,7 @@ class msProduct extends modResource
     {
         if ($this->options === null) {
             $this->options = $this->xpdo->call('msProductData', 'loadOptions', array(
-                &$this->xpdo,
+                $this->xpdo,
                 $this->loadData()->get('id'),
             ));
         }

--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -56,7 +56,7 @@ class msProductData extends xPDOSimpleObject
     *
     * @return array
     */
-    public static function loadOptions(xPDO & $xpdo, $product)
+    public static function loadOptions(xPDO $xpdo, $product)
     {
         $c = $xpdo->newQuery('msProductOption');
         $c->rightJoin('msOption', 'msOption', 'msProductOption.key=msOption.key');


### PR DESCRIPTION
### Что оно делает?

Удалены ссылки на объекты как legacy код. 

### Зачем это нужно?

Передача объекта по ссылке - это механика из PHP < 5.0
В актуальных версиях PHP любые передаваемые из метода в метод объекты автоматически формируют ссылку на объект.
Нет необходимости указывать ссылки.  Это может привести к проблемам

[Подробнее  ](https://modzone.ru/blog/2019/05/15/pass-objects-by-reference/)


