### PR TITLE
Добавил учитывание настроек дня недели в датах фильтрации заказов

### DIFF
--- a/assets/components/minishop2/js/mgr/orders/orders.form.js
+++ b/assets/components/minishop2/js/mgr/orders/orders.form.js
@@ -50,6 +50,7 @@ Ext.extend(miniShop2.panel.OrdersForm, MODx.FormPanel, {
             emptyText: _('ms2_orders_form_begin'),
             name: 'date_start',
             format: MODx.config['manager_date_format'] || 'Y-m-d',
+            startDay: +MODx.config['manager_week_start'] || 0,
             listeners: {
                 select: {
                     fn: function () {
@@ -63,6 +64,7 @@ Ext.extend(miniShop2.panel.OrdersForm, MODx.FormPanel, {
             emptyText: _('ms2_orders_form_end'),
             name: 'date_end',
             format: MODx.config['manager_date_format'] || 'Y-m-d',
+            startDay: +MODx.config['manager_week_start'] || 0,
             listeners: {
                 select: {
                     fn: function () {


### PR DESCRIPTION
### Что оно делает?
Добавил учитывание настроек дня недели в датах фильтрации заказов. Раньше всегда стояло воскресенье, теперь будет тот день, который указан в "Системных настройках" MODX.

![w_start_1](https://user-images.githubusercontent.com/12523676/113420165-81334180-93d1-11eb-9fa8-50fee2cb6215.png)

![w_start_2](https://user-images.githubusercontent.com/12523676/113420166-81cbd800-93d1-11eb-9221-168ff98aba08.png)

### Зачем это нужно?
UX улучшение 

### Связанные проблема(ы)/PR(ы)
Нет
