### PR TITLE
Fixed the logic of registration of the order status label in the order history

### DIFF
--- a/assets/components/minishop2/js/mgr/orders/orders.grid.logs.js
+++ b/assets/components/minishop2/js/mgr/orders/orders.grid.logs.js
@@ -38,7 +38,7 @@ Ext.extend(miniShop2.grid.Logs, miniShop2.grid.Default, {
                 width: 75
         },
             {header: _('ms2_action'), dataIndex: 'action', width: 50},
-            {header: _('ms2_entry'), dataIndex: 'entry', width: 50}
+            {header: _('ms2_entry'), dataIndex: 'entry', width: 50, renderer: miniShop2.utils.renderBadge}
         ];
     },
 

--- a/core/components/minishop2/docs/changelog.txt
+++ b/core/components/minishop2/docs/changelog.txt
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.9-pl] - TDB
+
+### Added
+
+- Replace ssl certificat for paypal [#573]
+
+### Changed
+
+- Fixed the logic of registration of the order status label in the order history [#576]
+- Bringing the code to the PSR12 standard [#574]
+
 ## [2.8.3-pl] - 2021-04-01
 
 ### Changed

--- a/core/components/minishop2/processors/mgr/orders/getlog.class.php
+++ b/core/components/minishop2/processors/mgr/orders/getlog.class.php
@@ -122,7 +122,7 @@ class msOrderLogGetListProcessor extends modObjectGetListProcessor
     public function prepareArray(array $data)
     {
         if (!empty($data['color'])) {
-            $data['entry'] = '<span style="color:#' . $data['color'] . ';">' . $data['entry'] . '</span>';
+            $data['entry'] = '<span>' . $data['entry'] . '</span>';
         }
 
         return $data;


### PR DESCRIPTION
### Что оно делает?

Исправлена логика формирования css-стиля статуса заказа в истории заказа по примеру оформления списка заказов.
### Зачем это нужно?

#571 

### Связанные проблема(ы)/PR(ы)

#571 