### PR TITLE
Added wiretapping of initiated context for work from API

### DIFF
--- a/core/components/minishop2/docs/changelog.txt
+++ b/core/components/minishop2/docs/changelog.txt
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.8.3-pl] - 2021-04-01
 
+### Added
+
+- Added wiretapping of initiated context for work from API [#578]
+
 ### Changed
 
 - Regular expression update to validate phone number [#563]

--- a/core/components/minishop2/model/minishop2/mscarthandler.class.php
+++ b/core/components/minishop2/model/minishop2/mscarthandler.class.php
@@ -131,7 +131,8 @@ class msCartHandler implements msCartInterface
     */
     public function initialize($ctx = 'web')
     {
-        if ($this->modx->getOption('ms2_cart_context', null, '', true) == 1) {
+        $ms2_cart_context = (bool)$this->modx->getOption('ms2_cart_context', null, '0', true);
+        if ($ms2_cart_context) {
             $ctx = 'web';
         }
         $this->ctx = $ctx;
@@ -212,8 +213,9 @@ class msCartHandler implements msCartInterface
                 return $this->change($key, $this->cart[$key]['count'] + $count);
             } else {
                 $ctx_key = 'web';
-                if (!$this->modx->getOption('ms2_cart_context', null, '', true)) {
-                    $ctx_key = $this->modx->context->get('key');
+                $ms2_cart_context = (bool)$this->modx->getOption('ms2_cart_context', null, '0', true);
+                if (!$ms2_cart_context) {
+                    $ctx_key = $this->ctx;
                 }
                 $this->cart[$key] = array(
                     'id' => $id,


### PR DESCRIPTION
### Что оно делает?

- Отрефакторен участок кода связанный с общей корзиной для всех контекстов
- Добавлена прослушка инициированного контекста для работы из API
 
### Зачем это нужно?

Если я работаю с минишопом в режиме API и задаю контекст отличающийся от того, в котором нахожусь - Системная настройка `ms2_cart_context `в корзине игнорирует заданный контекст автоматически присваивая текущий.

### Связанные проблема(ы)/PR(ы)

#569 
