### PR TITLE
fix create ms2_options in innoDB

### DIFF
--- a/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
+++ b/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
@@ -445,7 +445,7 @@
 
     <object class="msOption" table="ms2_options" extends="xPDOSimpleObject">
         <field key="key" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index"/>
-        <field key="caption" dbtype="varchar" precision="255" phptype="string" null="false" default=""
+        <field key="caption" dbtype="varchar" precision="191" phptype="string" null="false" default=""
             index="fulltext"/>
         <field key="description" dbtype="text" phptype="string" null="true"/>
         <field key="measure_unit" dbtype="tinytext" phptype="string" null="true"/>

--- a/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
+++ b/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
@@ -444,13 +444,13 @@
     </object>
 
     <object class="msOption" table="ms2_options" extends="xPDOSimpleObject">
-        <field key="key" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index"/>
+        <field key="key" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index"/>
         <field key="caption" dbtype="varchar" precision="255" phptype="string" null="false" default=""
             index="fulltext"/>
         <field key="description" dbtype="text" phptype="string" null="true"/>
         <field key="measure_unit" dbtype="tinytext" phptype="string" null="true"/>
         <field key="category" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false"/>
-        <field key="type" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index"/>
+        <field key="type" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index"/>
         <field key="properties" dbtype="text" phptype="json" null="true"/>
 
         <index alias="key" name="key" primary="false" unique="true" type="BTREE">


### PR DESCRIPTION
### Что оно делает?

Исправляет #572

### Зачем это нужно?

Исправляет создание таблицы в innoDB на стандартных настройках

PR нужно протестировать, может что-то упустил. 

### Как протестировать?
Установка на чистую innoDB, также нужно проверить на рабочем проекте, так как урезано количество символов 
