### PR TITLE
Поля msVendor в списке товаров заказа

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -237,7 +237,7 @@ $tmp = array(
     ),
     'ms2_order_product_fields' => array(
         'xtype' => 'textarea',
-        'value' => 'product_pagetitle,product_article,weight,price,count,cost',
+        'value' => 'product_pagetitle,vendor_name,product_article,weight,price,count,cost',
         'area' => 'ms2_order',
     ),
     'ms2_order_product_options' => array(

--- a/assets/components/minishop2/js/mgr/orders/orders.grid.products.js
+++ b/assets/components/minishop2/js/mgr/orders/orders.grid.products.js
@@ -65,6 +65,14 @@ Ext.extend(miniShop2.grid.OrderProducts, miniShop2.grid.Default, {
                 columns.push(
                     {header: _(field.replace(/^category_/, 'ms2_')), dataIndex: field, width: 75}
                 );
+            } else if(/^vendor_name/.test(field)) {
+                columns.push(
+                    {header: _('ms2_product_vendor'), dataIndex: field, width: 75}
+                );
+            } else if(/^vendor_/.test(field)) {
+                columns.push(
+                    {header: _(field.replace(/^vendor_/, 'ms2_')), dataIndex: field, width: 75}
+                );
             }
         }
 

--- a/core/components/minishop2/processors/mgr/orders/product/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/orders/product/getlist.class.php
@@ -33,6 +33,8 @@ class msOrderProductGetListProcessor extends modObjectGetListProcessor
         $c->leftJoin('msProduct', 'msProduct', '`msOrderProduct`.`product_id` = `msProduct`.`id`');
         $c->leftJoin('msProductData', 'msProductData', '`msOrderProduct`.`product_id` = `msProductData`.`id`');
         $c->leftJoin('msCategory', 'msCategory', '`msProduct`.`parent` = `msCategory`.`id`');
+        $c->leftJoin('msVendor', 'msVendor', '`msProductData`.`vendor` = `msVendor`.`id`');
+        $c->select($this->modx->getSelectColumns('msVendor', 'msVendor', 'vendor_', array('id'), true));
         $c->where(array(
             'order_id' => $this->getProperty('order_id'),
         ));


### PR DESCRIPTION
### Что оно делает?

Добавляет поля объекта msVendor в список товаров заказа.

### Зачем это нужно?

Чтобы видеть производителя товара в этом спиcке.

### Связанные проблема(ы)/PR(ы)

Странно, что в этом же списке полно сопутствующей информации о товаре, но нет элементарной информации о производителе.

