### PR TITLE
Удалил неработающую проверку на изменения в ресурсах

### DIFF
--- a/assets/components/minishop2/js/mgr/category/create.js
+++ b/assets/components/minishop2/js/mgr/category/create.js
@@ -42,17 +42,7 @@ Ext.extend(miniShop2.page.CreateCategory, MODx.page.CreateResource, {
             ? 'resource/update'
             : 'welcome';
 
-        var fp = Ext.getCmp(this.config.formpanel);
-        if (fp && fp.isDirty() && MODx.config['confirm_navigation'] == 1) {
-            Ext.Msg.confirm(_('warning'), _('resource_cancel_dirty_confirm'), function (e) {
-                if (e == 'yes') {
-                    fp.warnUnsavedChanges = false;
-                    MODx.loadPage(action, 'id=' + id)
-                }
-            }, this);
-        } else {
-            MODx.loadPage(action, 'id=' + id)
-        }
+        MODx.loadPage(action, 'id=' + id)
     },
 
 });

--- a/assets/components/minishop2/js/mgr/category/update.js
+++ b/assets/components/minishop2/js/mgr/category/update.js
@@ -90,17 +90,7 @@ Ext.extend(miniShop2.page.UpdateCategory, MODx.page.UpdateResource, {
             ? 'resource/update'
             : 'welcome';
 
-        var fp = Ext.getCmp(this.config.formpanel);
-        if (fp && fp.isDirty() && MODx.config['confirm_navigation'] == 1) {
-            Ext.Msg.confirm(_('warning'), _('resource_cancel_dirty_confirm'), function (e) {
-                if (e == 'yes') {
-                    fp.warnUnsavedChanges = false;
-                    MODx.loadPage(action, 'id=' + id)
-                }
-            }, this);
-        } else {
-            MODx.loadPage(action, 'id=' + id)
-        }
+        MODx.loadPage(action, 'id=' + id)
     },
 
 });

--- a/assets/components/minishop2/js/mgr/product/create.js
+++ b/assets/components/minishop2/js/mgr/product/create.js
@@ -42,17 +42,7 @@ Ext.extend(miniShop2.page.CreateProduct, MODx.page.CreateResource, {
             ? 'resource/update'
             : 'welcome';
 
-        var fp = Ext.getCmp(this.config.formpanel);
-        if (fp && fp.isDirty() && MODx.config['confirm_navigation'] == 1) {
-            Ext.Msg.confirm(_('warning'), _('resource_cancel_dirty_confirm'), function (e) {
-                if (e == 'yes') {
-                    fp.warnUnsavedChanges = false;
-                    MODx.loadPage(action, 'id=' + id)
-                }
-            }, this);
-        } else {
-            MODx.loadPage(action, 'id=' + id)
-        }
+        MODx.loadPage(action, 'id=' + id)
     },
 
 });

--- a/assets/components/minishop2/js/mgr/product/update.js
+++ b/assets/components/minishop2/js/mgr/product/update.js
@@ -86,17 +86,7 @@ Ext.extend(miniShop2.page.UpdateProduct, MODx.page.UpdateResource, {
             ? 'resource/update'
             : 'welcome';
 
-        var fp = Ext.getCmp(this.config.formpanel);
-        if (fp && fp.isDirty() && MODx.config['confirm_navigation'] == 1) {
-            Ext.Msg.confirm(_('warning'), _('resource_cancel_dirty_confirm'), function (e) {
-                if (e == 'yes') {
-                    fp.warnUnsavedChanges = false;
-                    MODx.loadPage(action, 'id=' + id)
-                }
-            }, this);
-        } else {
-            MODx.loadPage(action, 'id=' + id)
-        }
+        MODx.loadPage(action, 'id=' + id)
     },
 
 });

--- a/core/components/minishop2/lexicon/be/product.inc.php
+++ b/core/components/minishop2/lexicon/be/product.inc.php
@@ -119,8 +119,6 @@ $_lang['ms2_product_prev'] = 'Папярэдні тавар';
 $_lang['ms2_product_next'] = 'Наступны тавар';
 $_lang['ms2_product_help'] = 'Дапамога';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'У вас ёсць адкладзеныя змены. Вы сапраўды жадаеце адмяніць?';
 $_lang['ms2_product_duplicate_confirm'] = 'Вы ўпэўненыя, што хочаце зрабіць копію гэтага тавару?';
 $_lang['ms2_product_delete_desc'] = 'Вы сапраўды хочаце выдаліць гэты тавар?';
 $_lang['ms2_product_selected_publish'] = 'Уключыць выбраныя тавары';

--- a/core/components/minishop2/lexicon/de/product.inc.php
+++ b/core/components/minishop2/lexicon/de/product.inc.php
@@ -112,8 +112,6 @@ $_lang['ms2_product_prev'] = 'Vorheriges Produkt';
 $_lang['ms2_product_next'] = 'Nächstes Produkt';
 $_lang['ms2_product_help'] = 'Hilfe';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'Änderungen wurden vorgenommen; wirklich abbrechen?';
 $_lang['ms2_product_duplicate_confirm'] = 'Produkt wirklich duplizieren?';
 $_lang['ms2_product_delete_desc'] = 'Dieses Produkt wirklich löschen?';
 $_lang['ms2_product_selected_publish'] = 'Ausgewählte Produkte veröffentlichen';

--- a/core/components/minishop2/lexicon/en/product.inc.php
+++ b/core/components/minishop2/lexicon/en/product.inc.php
@@ -119,8 +119,6 @@ $_lang['ms2_product_prev'] = 'Previous product';
 $_lang['ms2_product_next'] = 'Next product';
 $_lang['ms2_product_help'] = 'Help';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'You have changes pending; are you sure you want to cancel?';
 $_lang['ms2_product_duplicate_confirm'] = 'Are you sure you want to make a copy of this product?';
 $_lang['ms2_product_delete_desc'] = 'Do you really want to delete this product?';
 $_lang['ms2_product_selected_publish'] = 'Publish selected goods';

--- a/core/components/minishop2/lexicon/fr/product.inc.php
+++ b/core/components/minishop2/lexicon/fr/product.inc.php
@@ -112,8 +112,6 @@ $_lang['ms2_product_prev'] = 'Article précédent';
 $_lang['ms2_product_next'] = 'Article suivant';
 $_lang['ms2_product_help'] = 'Aide';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'Vous avez des modification en attente, êtes vous sûr de vouloir annuler ?';
 $_lang['ms2_product_duplicate_confirm'] = 'Ếtes vous sûr de vouloir faire une copie de cet article ?';
 $_lang['ms2_product_delete_desc'] = 'Voulez vous vraiement supprimer cet article ?';
 $_lang['ms2_product_selected_publish'] = 'Publier l\'article sélectionné';

--- a/core/components/minishop2/lexicon/it/product.inc.php
+++ b/core/components/minishop2/lexicon/it/product.inc.php
@@ -119,8 +119,6 @@ $_lang['ms2_product_prev'] = 'Ankstesnė prekė';
 $_lang['ms2_product_next'] = 'Kita prekė';
 $_lang['ms2_product_help'] = 'Pagalba';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'Yra neįrašytų pakeitimų, ar tikrai norite jų atsisakyti?';
 $_lang['ms2_product_duplicate_confirm'] = 'Ar tikrai norite kurti šios prekės kopiją?';
 $_lang['ms2_product_delete_desc'] = 'Ar tikrai norite pašalinti šią prekę?';
 $_lang['ms2_product_selected_publish'] = 'Publikuoti pasirinktas prekes';

--- a/core/components/minishop2/lexicon/lt/product.inc.php
+++ b/core/components/minishop2/lexicon/lt/product.inc.php
@@ -115,8 +115,6 @@ $_lang['ms2_product_prev'] = 'Ankstesnė prekė';
 $_lang['ms2_product_next'] = 'Kita prekė';
 $_lang['ms2_product_help'] = 'Pagalba';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'Yra neįrašytų pakeitimų, ar tikrai norite jų atsisakyti?';
 $_lang['ms2_product_duplicate_confirm'] = 'Ar tikrai norite kurti šios prekės kopiją?';
 $_lang['ms2_product_delete_desc'] = 'Ar tikrai norite pašalinti šią prekę?';
 $_lang['ms2_product_selected_publish'] = 'Publikuoti pasirinktas prekes';

--- a/core/components/minishop2/lexicon/nl/product.inc.php
+++ b/core/components/minishop2/lexicon/nl/product.inc.php
@@ -119,8 +119,6 @@ $_lang['ms2_product_prev'] = 'Vorige product';
 $_lang['ms2_product_next'] = 'Volgende product';
 $_lang['ms2_product_help'] = 'Hulp';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'Je hebt onopgeslagen wijzigingen; weet je zeker dat je wilt annuleren?';
 $_lang['ms2_product_duplicate_confirm'] = 'Weet je zeker dat je een kopie wilt maken van dit product?';
 $_lang['ms2_product_delete_desc'] = 'Weet je zeker dat je dit product wilt verwijderen?';
 $_lang['ms2_product_selected_publish'] = 'Publiceer geselecteerde producten';

--- a/core/components/minishop2/lexicon/ro/product.inc.php
+++ b/core/components/minishop2/lexicon/ro/product.inc.php
@@ -120,8 +120,6 @@ $_lang['ms2_product_prev'] = 'Produsul anterior';
 $_lang['ms2_product_next'] = 'Produsul următor';
 $_lang['ms2_product_help'] = 'Ajutor';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'Aveți modificări în așteptare. Sunteți sigur că doriți să anulați';
 $_lang['ms2_product_duplicate_confirm'] = 'Sunteți sigur că doriți să faceți copia acestui produs?';
 $_lang['ms2_product_delete_desc'] = 'Sunteți sigur că doriți să eliminați acest produs?';
 $_lang['ms2_product_selected_publish'] = 'A publica produsele selectate';

--- a/core/components/minishop2/lexicon/ru/product.inc.php
+++ b/core/components/minishop2/lexicon/ru/product.inc.php
@@ -119,8 +119,6 @@ $_lang['ms2_product_prev'] = 'Предыдущий товар';
 $_lang['ms2_product_next'] = 'Следующий товар';
 $_lang['ms2_product_help'] = 'Помощь';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'У вас есть отложенные изменения. Вы действительно хотите отменить?';
 $_lang['ms2_product_duplicate_confirm'] = 'Вы уверены, что хотите сделать копию этого товара?';
 $_lang['ms2_product_delete_desc'] = 'Вы действительно хотите удалить этот товар?';
 $_lang['ms2_product_selected_publish'] = 'Включить выбранные товары';

--- a/core/components/minishop2/lexicon/uk/product.inc.php
+++ b/core/components/minishop2/lexicon/uk/product.inc.php
@@ -119,8 +119,6 @@ $_lang['ms2_product_prev'] = 'Попередній товар';
 $_lang['ms2_product_next'] = 'Наступний товар';
 $_lang['ms2_product_help'] = 'Допомога';
 
-
-$_lang['ms2_product_dirty_confirm'] = 'У вас є відкладені зміни. Ви дійсно бажаєте відмінити?';
 $_lang['ms2_product_duplicate_confirm'] = 'Ви впевнені, що бажаєте зробити копію цього товару?';
 $_lang['ms2_product_delete_desc'] = 'Ви дійсно бажаєте видалити цей товар?';
 $_lang['ms2_product_selected_publish'] = 'Увімкнути вибрані товари';


### PR DESCRIPTION
### Что оно делает?
В miniShop2 при переходе "Наверх" была добавлена проверка на несохраненные изменения в виде всплывашки, мало того, что всплывашка была навешана только для "Наверх" (но не для, например, "Следующий/Предыдущий товар"), так **проверка еще и не работала**.

Удалил ненужную проверку и лексиконы.
Теперь используется обычная проверка с браузерным окном (по умолчанию в MODX), как на других кнопках и **оно работает**.

До:
![save_warn_1](https://user-images.githubusercontent.com/12523676/134161176-289c692b-270e-4874-85dc-e856cae1194c.gif)

После:
![save_warn_2](https://user-images.githubusercontent.com/12523676/134161191-2a42c1da-8b80-4d41-a112-0b20151127af.gif)

### Зачем это нужно?
- Был раздражающий баг.
- Меньше кода.

### Связанные проблема(ы)/PR(ы)
Нету
