### PR TITLE
Корректный http код ответа

### DIFF
--- a/assets/components/minishop2/action.php
+++ b/assets/components/minishop2/action.php
@@ -1,7 +1,7 @@
 <?php
 
 if (empty($_REQUEST['action']) && empty($_REQUEST['ms2_action'])) {
-    die('Access denied');
+    http_response_code(403);
 }
 
 if (!empty($_REQUEST['action'])) {


### PR DESCRIPTION
### Что оно делает?

Отдает корректный http код 403 в случае несанкционированного доступа к файлу

### Зачем это нужно?

В случае обращения к файлу action.php  он доступен с кодом 200, хоть и ругается access denied
Такого быть не должно,  Права доступа нужно разруливать на основе http ответов, а не просто текста.

### Связанные проблема(ы)/PR(ы)

#599 