### PR TITLE
добавил free_delivery_amount в прослушку цен

### DIFF
--- a/core/components/minishop2/processors/mgr/settings/delivery/create.class.php
+++ b/core/components/minishop2/processors/mgr/settings/delivery/create.class.php
@@ -39,12 +39,10 @@ class msDeliveryCreateProcessor extends modObjectCreateProcessor
             $this->modx->error->addField('name', $this->modx->lexicon('ms2_err_ae'));
         }
 
-        $prices = array('price', 'distance_price', 'weight_price');
+        $prices = array('price', 'distance_price', 'weight_price', 'free_delivery_amount');
         foreach ($prices as $field) {
-            if ($tmp = $this->getProperty($field)) {
-                $tmp = $this->preparePrice($tmp);
-                $this->setProperty($field, $tmp);
-            }
+            $tmp = $this->preparePrice($tmp);
+            $this->setProperty($field, $tmp);
         }
 
         return !$this->hasErrors();

--- a/core/components/minishop2/processors/mgr/settings/delivery/update.class.php
+++ b/core/components/minishop2/processors/mgr/settings/delivery/update.class.php
@@ -40,7 +40,7 @@ class msDeliveryUpdateProcessor extends modObjectUpdateProcessor
             $this->modx->error->addField('name', $this->modx->lexicon('ms2_err_ae'));
         }
 
-        $prices = array('price', 'distance_price', 'weight_price');
+        $prices = array('price', 'distance_price', 'weight_price', 'free_delivery_amount');
         foreach ($prices as $field) {
             if ($tmp = $this->getProperty($field)) {
                 $tmp = $this->preparePrice($tmp);


### PR DESCRIPTION
### Что оно делает?

1. Добавил поле free_delivery_amount  в секцию, корректно форматирующую деньги
2. При создании нового метода доставки убрал не нужное условие, при котором пустое поле может передаться пустой строкой вместо 0, что вызывает ошибку записи в базу, при определенных условиях

### Зачем это нужно?

Новый способ доставки не сохраняется при незаполненном поле free_delivery_amount  