### PR TITLE
Добавляем Роль при рег-ии пользователя

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -708,7 +708,10 @@ class miniShop2
                     } elseif ($groups = $this->modx->getOption('ms2_order_user_groups', null, false)) {
                         $groups = array_map('trim', explode(',', $groups));
                         foreach ($groups as $group) {
-                            $customer->joinGroup($group);
+                            $grouprole = explode(':', $group);
+                            $role = null;
+                            if ($grouprole[1]) $role = $grouprole[1];
+                            $customer->joinGroup($grouprole[0],$role);
                         }
                     }
                 }

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -710,7 +710,11 @@ class miniShop2
                         foreach ($groups as $group) {
                             $grouprole = explode(':', $group);
                             if ($grouprole[1]) {
-                                $role = (int)$grouprole[1];
+                                if (is_numeric($grouprole[1])){
+                                    $role = (int)$grouprole[1];
+                                } else {
+                                    $role = $grouprole[1];
+                                }
                             } else {
                                 $role = null;
                             }

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -710,8 +710,11 @@ class miniShop2
                         foreach ($groups as $group) {
                             $grouprole = explode(':', $group);
                             $role = null;
-                            if ($grouprole[1]) $role = $grouprole[1];
-                            $customer->joinGroup($grouprole[0],$role);
+                            if ($grouprole[1])
+                                $role = (int)$grouprole[1];
+                            else
+                                $role = null;
+                            $customer->joinGroup($grouprole[0], $role);
                         }
                     }
                 }

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -706,8 +706,8 @@ class miniShop2
                     if (!$customer->save()) {
                         $customer = null;
                     } elseif ($groups = $this->modx->getOption('ms2_order_user_groups', null, false)) {
-                        $groups = array_map('trim', explode(',', $groups));
-                        foreach ($groups as $group) {
+                        $grouproles = array_map('trim', explode(',', $groups));
+                        foreach ($grouproles as $grouprole) {
                             $grouprole = explode(':', $group);
                             if ($grouprole[1]) {
                                 if (is_numeric($grouprole[1])) {

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -709,11 +709,11 @@ class miniShop2
                         $groups = array_map('trim', explode(',', $groups));
                         foreach ($groups as $group) {
                             $grouprole = explode(':', $group);
-                            $role = null;
-                            if ($grouprole[1])
+                            if ($grouprole[1]) {
                                 $role = (int)$grouprole[1];
-                            else
+                            } else {
                                 $role = null;
+                            }
                             $customer->joinGroup($grouprole[0], $role);
                         }
                     }

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -710,7 +710,7 @@ class miniShop2
                         foreach ($groups as $group) {
                             $grouprole = explode(':', $group);
                             if ($grouprole[1]) {
-                                if (is_numeric($grouprole[1])){
+                                if (is_numeric($grouprole[1])) {
                                     $role = (int)$grouprole[1];
                                 } else {
                                     $role = $grouprole[1];


### PR DESCRIPTION
Добавление поддержки роли для регистрации пользователя.

### Что оно делает?

Добавляет поддержку роли для регистрации пользователя. указывается Группа и после двоеточия РОЛЬ.

### Зачем это нужно?

Чтобы сразу регистрировать пользователя с нужной ролью.
**User:3** где 3 -это ID роли, так же роль можно писать текстом - MODX поддерживает это на уровне ядра, но для этого нужно чтобы явно приходило в метод _joinGroup_ (modUser) вторым параметром или строка или число с типом **int**.

Кстати Issue #629 если будет реализовано, то данный PR необходим будет уже точно.