### PR TITLE
Добавил очередь для писем

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -43,6 +43,17 @@ $tmp = array(
         'area' => 'ms2_main',
     ),
 
+    'ms2_queue' => array(
+        'value' => false,
+        'xtype' => 'combo-boolean',
+        'area' => 'ms2_main',
+    ),
+    'ms2_queue_limit' => array(
+        'value' => 10,
+        'xtype' => 'textfield',
+        'area' => 'ms2_main',
+    ),
+
     'ms2_category_grid_fields' => array(
         'value' => 'id,menuindex,pagetitle,article,price,thumb,new,favorite,popular',
         'xtype' => 'textarea',

--- a/assets/components/minishop2/queue/mail.php
+++ b/assets/components/minishop2/queue/mail.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var MODX $modx
  */

--- a/assets/components/minishop2/queue/mail.php
+++ b/assets/components/minishop2/queue/mail.php
@@ -25,7 +25,7 @@ if (!$queue) {
 }
 $q = $modx->newQuery('registry.db.modDbRegisterTopic');
 $q->where(['queue' => $queue->get('id')]);
-$q->limit($modx->getOption('ms2_queue_limit', '' ,10));
+$q->limit($modx->getOption('ms2_queue_limit', '', 10));
 $topics = $modx->getIterator('modDbRegisterTopic', $q);
 $emails = [];
 foreach ($topics as $topic) {

--- a/assets/components/minishop2/queue/mail.php
+++ b/assets/components/minishop2/queue/mail.php
@@ -7,8 +7,7 @@
 if (file_exists(dirname(__FILE__, 6) . '/config.core.php')) {
     /** @noinspection PhpIncludeInspection */
     require_once dirname(__FILE__, 6) . '/config.core.php';
-} 
-else {
+} else {
     require_once dirname(__FILE__, 5) . '/config.core.php';
 }
 /** @noinspection PhpIncludeInspection */

--- a/assets/components/minishop2/queue/mail.php
+++ b/assets/components/minishop2/queue/mail.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @var MODX $modx
+ */
+
+if (file_exists(dirname(__FILE__, 6) . '/config.core.php')) {
+    /** @noinspection PhpIncludeInspection */
+    require_once dirname(__FILE__, 6) . '/config.core.php';
+}
+else {
+    require_once dirname(__FILE__, 5) . '/config.core.php';
+}
+/** @noinspection PhpIncludeInspection */
+require_once MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
+/** @noinspection PhpIncludeInspection */
+require_once MODX_CONNECTORS_PATH . 'index.php';
+$ms2 = $modx->getService('miniShop2');
+$modx->getService('registry', 'registry.modRegistry');
+$modx->registry->getRegister('minishop2', 'registry.modDbRegister');
+//Выбираем нужные очереди
+$queue = $modx->getObject('modDbRegisterQueue', ['name' => 'minishop2']);
+if (!$queue) {
+    return;
+}
+$q = $modx->newQuery('registry.db.modDbRegisterTopic');
+$q->where(['queue' => $queue->get('id')]);
+$q->limit($modx->getOption('ms2_queue_limit', '' ,10));
+$topics = $modx->getIterator('modDbRegisterTopic', $q);
+$emails = [];
+foreach ($topics as $topic) {
+    $modx->registry->minishop2->subscribe($topic->name);
+    $arRegistry = [
+        'poll_limit' => 1,
+        'msg_limit' => 10,
+        'include_keys' => false
+    ];
+    $msgs = $modx->registry->minishop2->read($arRegistry);
+    if (!$msgs) {
+        continue;
+    }
+
+    $msgs = json_decode($msgs[0], true);
+    $mail = $modx->getService('mail', 'mail.modPHPMailer');
+    $mail->setHTML(true);
+
+    $mail->address('to', $msgs['to']);
+    $mail->set(modMail::MAIL_SUBJECT, $msgs['mail_subject']);
+    $mail->set(modMail::MAIL_BODY, $msgs['mail_body']);
+    $mail->set(modMail::MAIL_FROM, $msgs['mail_from']);
+    $mail->set(modMail::MAIL_FROM_NAME, $msgs['mail_from_name']);
+    if (!$mail->send()) {
+        $ms2->queue($msgs['to'], $msgs['mail_subject'], $msgs['mail_body']);
+        $modx->log(
+            modX::LOG_LEVEL_ERROR,
+            'An error occurred while trying to send the email: ' . $mail->mailer->ErrorInfo
+        );
+    }
+    $mail->reset();
+    $topic->remove();
+}

--- a/assets/components/minishop2/queue/mail.php
+++ b/assets/components/minishop2/queue/mail.php
@@ -7,7 +7,7 @@
 if (file_exists(dirname(__FILE__, 6) . '/config.core.php')) {
     /** @noinspection PhpIncludeInspection */
     require_once dirname(__FILE__, 6) . '/config.core.php';
-}
+} 
 else {
     require_once dirname(__FILE__, 5) . '/config.core.php';
 }

--- a/core/components/minishop2/lexicon/ru/setting.inc.php
+++ b/core/components/minishop2/lexicon/ru/setting.inc.php
@@ -16,6 +16,12 @@ $_lang['area_ms2_order'] = 'Заказы';
 $_lang['area_ms2_frontend'] = 'Сайт';
 $_lang['area_ms2_payment'] = 'Платежи';
 
+$_lang['setting_ms2_queue'] = 'Использовать очередь для писем?';
+$_lang['setting_ms2_queue_desc'] = 'Если вколючено, то отправка писем будет осуществляться с помощью очереди. Не забудьте добавить в крон файлик /assets/components/minishop2/queue/mail.php';
+
+$_lang['setting_ms2_queue_limit'] = 'Количество отправляемых писем за одну итерацию';
+$_lang['setting_ms2_queue_limit_desc'] = 'Установите в зависимости от мощности вашего хостинга';
+
 $_lang['setting_ms2_services'] = 'Службы магазина';
 $_lang['setting_ms2_services_desc'] = 'Массив с зарегистрированными классами для корзины, заказа, доставки и оплаты. Используется сторонними дополнениями для загрузки своего функционала.';
 $_lang['setting_ms2_plugins'] = 'Плагины магазина';


### PR DESCRIPTION
### Что оно делает?

Добавляет возможность отправлять письма в очередь для отправки пользователю

### Зачем это нужно?

Иногда письмо отправляется очень долго, и отправка заказа обрабатывается для пользователя долго.

Выведены настройки для включения работы очереди
Нужно добавить в крон скрипт /assets/components/minishop2/queue/mail.php
