### PR TITLE
Добавить возможность сортировать опции на странице категории

### DIFF
--- a/assets/components/minishop2/js/mgr/category/option.grid.js
+++ b/assets/components/minishop2/js/mgr/category/option.grid.js
@@ -39,7 +39,7 @@ Ext.extend(miniShop2.grid.CategoryOption, miniShop2.grid.Default, {
             {header: _('ms2_ft_caption'), dataIndex: 'caption', width: 75, sortable: true},
             {header: _('ms2_ft_type'), dataIndex: 'type', width: 75, renderer: this._renderType},
             {header: _('ms2_default_value'), dataIndex: 'value', width: 75, editor: {xtype: 'textfield'}},
-            {header: _('ms2_ft_rank'), dataIndex: 'rank', width: 50, editor: {xtype: 'numberfield'}, hidden: true},
+            {header: _('ms2_ft_rank'), dataIndex: 'rank', width: 50, editor: {xtype: 'numberfield'}, hidden: true, sortable: true},
             {
                 header: _('ms2_actions'),
                 width: 75,


### PR DESCRIPTION
### Что оно делает?

Исправление добавляет возможность отсортировать опции в том порядке, который указан в поле rank.

### Зачем это нужно?

Сейчас, когда работаешь в опциями на  странице категории, нет возможности визуально выстроить опции в том порядке, в котором они должны быть согласно полю `rank`. Вполне очевидная недоработка.

### Как тестировать?

Добавить в настройках MS несколько опций, зайти в любую категорию и добавить туда созданные опции.
Ткнуть на стрелочку над любым полем таблицы и выбрать внизу пункт "Столбцы", там отметить галочкой "Порядок сортировки" (по умолчанию поле скрыто). После этого заполнить поле значениями и попробовать отсортировать в обоих направлениях.

### Связанные проблема(ы)/PR(ы)

N/A