### PR TITLE
Добавил возможность генерировать превью товара прямо с грида

### DIFF
--- a/core/components/minishop2/processors/mgr/product/getlist.class.php
+++ b/core/components/minishop2/processors/mgr/product/getlist.class.php
@@ -264,7 +264,7 @@ class msProductGetListProcessor extends modObjectGetListProcessor
             //Regenerate image
             $array['actions'][] = [
                 'cls' => '',
-                'icon' => 'icon icon-refresh',
+                'icon' => 'icon icon-file-image-o',
                 'title' => $this->modx->lexicon('ms2_gallery_file_generate_thumbs'),
                 'action' => 'generatePreview',
                 'button' => false,


### PR DESCRIPTION
### Что оно делает?

Теперь можно перегенерировать превью товара не заходя в сам товар
![image](https://user-images.githubusercontent.com/3878386/155930176-55285905-d5d3-46ec-b372-002f60819d18.png)


### Зачем это нужно?

Иногда очень не удобно заходить в каждый товар и во вкладке галерея делать генерацию превью
