### PR TITLE
Добавлена возможность указать номер роли при регистрации пользователя

### DIFF
--- a/core/components/minishop2/docs/changelog.txt
+++ b/core/components/minishop2/docs/changelog.txt
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.0.2-pl] - 2022-05-20
 
 ### Added
+- The ability to update image previews in the product grid
+- The ability to specify the role number when registering a user
+- Lost system setting ms2_cart_max_count
+
+### Changed
 - msCartHandler, msOrderHandler, msDeliveryHandler, msPaymentHandler deprecated file notifications now listen to the log_deprecated system setting
 - Escaping of the rank field to support mysql 8
-- Added the ability to update image previews in the product grid
 
 ## [3.0.1-pl] - 2022-05-04
 

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -710,9 +710,19 @@ class miniShop2
                     if (!$customer->save()) {
                         $customer = null;
                     } elseif ($groups = $this->modx->getOption('ms2_order_user_groups', null, false)) {
-                        $groups = array_map('trim', explode(',', $groups));
-                        foreach ($groups as $group) {
-                            $customer->joinGroup($group);
+                        $groupRoles = array_map('trim', explode(',', $groups));
+                        foreach ($groupRoles as $groupRole) {
+                            $groupRole = explode(':', $groupRole);
+                            if (count($groupRole) > 1 && !empty($groupRole[1])) {
+                                if (is_numeric($groupRole[1])) {
+                                    $roleId = (int)$groupRole[1];
+                                } else {
+                                    $roleId = $groupRole[1];
+                                }
+                            } else {
+                                $roleId = null;
+                            }
+                            $customer->joinGroup($groupRole[0], $roleId);
                         }
                     }
                 }


### PR DESCRIPTION
### Что оно делает?

Добавляет поддержку роли для регистрации пользователя. указывается Группа и после двоеточия РОЛЬ.


### Зачем это нужно?

Чтобы сразу регистрировать пользователя с нужной ролью.
User:3 где 3 -это ID роли, так же роль можно писать текстом - MODX поддерживает это на уровне ядра, но для этого нужно чтобы явно приходило в метод joinGroup (modUser) вторым параметром или строка или число с типом int.

### Связанные проблема(ы)/PR(ы)

#652 
