### PR TITLE
3.0.3

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -4,7 +4,7 @@
 const PKG_NAME = 'miniShop2';
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-const PKG_VERSION = '3.0.2';
+const PKG_VERSION = '3.0.3';
 const PKG_RELEASE = 'pl';
 const PKG_AUTO_INSTALL = true;
 

--- a/core/components/minishop2/docs/changelog.txt
+++ b/core/components/minishop2/docs/changelog.txt
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3-pl] - 2022-05-30
+
+### Changed
+- Fixed error with escaping of the rank on object msOrderStatus
+- Added escaping of the rank in upload processor
+- Returned the ability to add any fields to the order object
+
 ## [3.0.2-pl] - 2022-05-20
 
 ### Added

--- a/core/components/minishop2/handlers/storage/session/ordersessionhandler.class.php
+++ b/core/components/minishop2/handlers/storage/session/ordersessionhandler.class.php
@@ -46,19 +46,15 @@ class OrderSessionHandler
         $createdon = date('Y-m-d H:i:s');
         /** @var msOrder $msOrder */
         $msOrder = $this->modx->newObject('msOrder');
-        $msOrder->fromArray(array(
-            'user_id' => $data['user_id'],
+
+        $orderData = array_merge($order, $data, [
             'createdon' => $createdon,
-            'num' => $data['num'],
-            'delivery' => $order['delivery'],
-            'payment' => $order['payment'],
-            'cart_cost' => $data['cart_cost'],
             'weight' => $data['cart_status']['total_weight'],
-            'delivery_cost' => $data['delivery_cost'],
             'cost' => $data['cart_cost'] + $data['delivery_cost'],
             'status' => 0,
             'context' => $this->ctx,
-        ));
+        ]);
+        $msOrder->fromArray($orderData);
 
         // Adding address
         /** @var msOrderAddress $address */

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -783,7 +783,7 @@ class miniShop2
                     $error = 'ms2_err_status_final';
                 } else {
                     if ($old_status->get('fixed')) {
-                        if ($status->get($this->modx->escape('rank')) <= $old_status->get($this->modx->escape('rank'))) {
+                        if ($status->get('rank') <= $old_status->get('rank')) {
                             $error = 'ms2_err_status_fixed';
                         }
                     }

--- a/core/components/minishop2/processors/mgr/gallery/upload.class.php
+++ b/core/components/minishop2/processors/mgr/gallery/upload.class.php
@@ -144,7 +144,7 @@ class msProductFileUploadProcessor extends modObjectProcessor
 
             if (empty($rank)) {
                 $imagesTable = $this->modx->getTableName($this->classKey);
-                $sql = "UPDATE {$imagesTable} SET rank = rank + 1 WHERE product_id ='" . $this->product->id . "' AND id !='" . $uploaded_file->get('id') . "'";
+                $sql = "UPDATE {$imagesTable} SET `rank` = `rank` + 1 WHERE product_id ='" . $this->product->id . "' AND id !='" . $uploaded_file->get('id') . "'";
                 $this->modx->exec($sql);
             }
 


### PR DESCRIPTION
### Что оно делает?

- Исправлена ошибка с ненужным экранированием поля msOrderStatus.rank 
- Добавлено экранирование поля rank в SQL запросе процессора Upload
- Возвращена возможность заполнения любых полей при создании заказа.


