### PR TITLE
Добавляет поле email в окно адреса заказа

### DIFF
--- a/assets/components/minishop2/js/mgr/orders/orders.window.js
+++ b/assets/components/minishop2/js/mgr/orders/orders.window.js
@@ -167,6 +167,7 @@ Ext.extend(miniShop2.window.UpdateOrder, miniShop2.window.Default, {
             room: {},
             entrance: {},
             floor: {},
+            email: {},
         };
         var fields = [], tmp = [];
         for (var i = 0; i < miniShop2.config['order_address_fields'].length; i++) {


### PR DESCRIPTION
### Что оно делает?

Если вписать в системных настройках поле email - то оно будет выводиться в окне с адресом заказа. 

### Зачем это нужно?

Так как в новой версии это поле теперь сохраняется в базе данных для адреса, то есть смысл дать возможность выводить его также как и остальные. 

