### PR TITLE
Добавлена проверки версий MODX PHP

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -247,6 +247,10 @@ $builder->setPackageAttributes(array(
     'setup-options' => array(
         'source' => $sources['build'] . 'setup.options.php',
     ),
+    'requires' => [
+        'php' => '>=7.0.0',
+        'modx' => '<3.0.0',
+    ],
 ));
 $modx->log(modX::LOG_LEVEL_INFO, 'Added package attributes and setup options.');
 


### PR DESCRIPTION
### Что оно делает?

В инсталятор добавлена проверка на Максимальную версию MODX  <  3.0.0 и минимальную версию PHP >= 7.0.0
### Зачем это нужно?

Установка компонента на MODX3 или на сайт с PHP 5.6 вызывает проблемы. 
