### PR TITLE
удалены устаревшие контроллеры

### DIFF
--- a/core/components/minishop2/model/minishop2/mscarthandler.class.php
+++ b/core/components/minishop2/model/minishop2/mscarthandler.class.php
@@ -1,9 +1,0 @@
-<?php
-
-if (!empty($this->modx->getOption('log_deprecated'))) {
-    $this->modx->log(
-        xPDO::LOG_LEVEL_ERROR,
-        'Deprecated: use handlers from catalog core/components/minishop2/handlers/'
-    );
-}
-require_once dirname(__FILE__, 3) . '/handlers/mscarthandler.class.php';

--- a/core/components/minishop2/model/minishop2/msdeliveryhandler.class.php
+++ b/core/components/minishop2/model/minishop2/msdeliveryhandler.class.php
@@ -1,9 +1,0 @@
-<?php
-
-if (!empty($this->modx->getOption('log_deprecated'))) {
-    $this->modx->log(
-        xPDO::LOG_LEVEL_ERROR,
-        'Deprecated: use handlers from catalog core/components/minishop2/handlers/'
-    );
-}
-require_once dirname(__FILE__, 3) . '/handlers/msdeliveryhandler.class.php';

--- a/core/components/minishop2/model/minishop2/msorderhandler.class.php
+++ b/core/components/minishop2/model/minishop2/msorderhandler.class.php
@@ -1,9 +1,0 @@
-<?php
-
-if (!empty($this->modx->getOption('log_deprecated'))) {
-    $this->modx->log(
-        xPDO::LOG_LEVEL_ERROR,
-        'Deprecated: use handlers from catalog core/components/minishop2/handlers/'
-    );
-}
-require_once dirname(__FILE__, 3) . '/handlers/msorderhandler.class.php';

--- a/core/components/minishop2/model/minishop2/mspaymenthandler.class.php
+++ b/core/components/minishop2/model/minishop2/mspaymenthandler.class.php
@@ -1,9 +1,0 @@
-<?php
-
-if (!empty($this->modx->getOption('log_deprecated'))) {
-    $this->modx->log(
-        xPDO::LOG_LEVEL_ERROR,
-        'Deprecated: use handlers from catalog core/components/minishop2/handlers/'
-    );
-}
-require_once dirname(__FILE__, 3) . '/handlers/mspaymenthandler.class.php';


### PR DESCRIPTION
### Что оно делает?

Удалены контроллеры из каталога Model
- mscarthandler
- msorderhandler
- mspaymenthandler
- msdeliveryhandler

### Зачем это нужно?

В версии 3.0.0 контроллеры были перенесены в отдельный каталог. На их месте были оставлены заглушки с записью в лог информации об устаревшем местонахождении. 


