### PR TITLE
Изменил связь между заказом и адресом заказа

### DIFF
--- a/core/components/minishop2/model/minishop2/metadata.mysql.php
+++ b/core/components/minishop2/model/minishop2/metadata.mysql.php
@@ -1,33 +1,33 @@
 <?php
 
-$xpdo_meta_map = array(
+$xpdo_meta_map = [
     'modResource' =>
-        array(
-            0 => 'msCategory',
-            1 => 'msProduct',
-        ),
+        [
+            'msCategory',
+            'msProduct',
+        ],
     'xPDOSimpleObject' =>
-        array(
-            0 => 'msProductData',
-            1 => 'msVendor',
-            2 => 'msProductFile',
-            3 => 'msDelivery',
-            4 => 'msPayment',
-            5 => 'msOrder',
-            6 => 'msOrderStatus',
-            7 => 'msOrderLog',
-            8 => 'msOrderAddress',
-            9 => 'msOrderProduct',
-            10 => 'msLink',
-            11 => 'msOption',
-        ),
+        [
+            'msProductData',
+            'msVendor',
+            'msProductFile',
+            'msDelivery',
+            'msPayment',
+            'msOrder',
+            'msOrderStatus',
+            'msOrderLog',
+            'msOrderAddress',
+            'msOrderProduct',
+            'msLink',
+            'msOption',
+        ],
     'xPDOObject' =>
-        array(
-            0 => 'msCategoryMember',
-            1 => 'msProductOption',
-            2 => 'msDeliveryMember',
-            3 => 'msProductLink',
-            4 => 'msCustomerProfile',
-            5 => 'msCategoryOption',
-        ),
-);
+        [
+            'msCategoryMember',
+            'msProductOption',
+            'msDeliveryMember',
+            'msProductLink',
+            'msCustomerProfile',
+            'msCategoryOption',
+        ],
+];

--- a/core/components/minishop2/model/minishop2/mysql/msorder.map.inc.php
+++ b/core/components/minishop2/model/minishop2/mysql/msorder.map.inc.php
@@ -19,7 +19,6 @@ $xpdo_meta_map['msOrder'] = array(
             'status' => 0,
             'delivery' => 0,
             'payment' => 0,
-            'address' => 0,
             'context' => 'web',
             'order_comment' => null,
             'properties' => null,
@@ -114,15 +113,6 @@ $xpdo_meta_map['msOrder'] = array(
                     'default' => 0,
                 ),
             'payment' =>
-                array(
-                    'dbtype' => 'int',
-                    'precision' => '10',
-                    'attributes' => 'unsigned',
-                    'phptype' => 'integer',
-                    'null' => true,
-                    'default' => 0,
-                ),
-            'address' =>
                 array(
                     'dbtype' => 'int',
                     'precision' => '10',
@@ -249,8 +239,8 @@ $xpdo_meta_map['msOrder'] = array(
             'Address' =>
                 array(
                     'class' => 'msOrderAddress',
-                    'local' => 'address',
-                    'foreign' => 'id',
+                    'local' => 'id',
+                    'foreign' => 'order_id',
                     'cardinality' => 'one',
                     'owner' => 'foreign',
                 ),

--- a/core/components/minishop2/model/minishop2/mysql/msorderaddress.map.inc.php
+++ b/core/components/minishop2/model/minishop2/mysql/msorderaddress.map.inc.php
@@ -7,6 +7,7 @@ $xpdo_meta_map['msOrderAddress'] = array(
     'extends' => 'xPDOSimpleObject',
     'fields' =>
         array(
+            'order_id' => null,
             'user_id' => null,
             'createdon' => null,
             'updatedon' => null,
@@ -29,6 +30,14 @@ $xpdo_meta_map['msOrderAddress'] = array(
         ),
     'fieldMeta' =>
         array(
+            'order_id' =>
+                array(
+                    'dbtype' => 'int',
+                    'precision' => '10',
+                    'attributes' => 'unsigned',
+                    'phptype' => 'integer',
+                    'null' => false,
+                ),
             'user_id' =>
                 array(
                     'dbtype' => 'int',
@@ -161,6 +170,22 @@ $xpdo_meta_map['msOrderAddress'] = array(
         ),
     'indexes' =>
         array(
+            'order_id' =>
+                array(
+                    'alias' => 'order_id',
+                    'primary' => false,
+                    'unique' => false,
+                    'type' => 'BTREE',
+                    'columns' =>
+                        array(
+                            'order_id' =>
+                                array(
+                                    'length' => '',
+                                    'collation' => 'A',
+                                    'null' => false,
+                                ),
+                        ),
+                ),
             'user_id' =>
                 array(
                     'alias' => 'user_id',

--- a/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
+++ b/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
@@ -251,8 +251,6 @@
             default="0"/>
         <field key="payment" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="true"
             default="0"/>
-        <field key="address" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="true"
-            default="0"/>
         <field key="context" dbtype="varchar" precision="100" phptype="string" null="true" default="web"/>
         <field key="order_comment" dbtype="text" phptype="string" null="true"/>
         <field key="properties" dbtype="text" phptype="json" null="true"/>
@@ -280,7 +278,7 @@
         <aggregate alias="Status" class="msOrderStatus" local="status" foreign="id" cardinality="one" owner="foreign"/>
         <aggregate alias="Delivery" class="msDelivery" local="delivery" foreign="id" cardinality="one" owner="foreign"/>
         <aggregate alias="Payment" class="msPayment" local="payment" foreign="id" cardinality="one" owner="foreign"/>
-        <composite alias="Address" class="msOrderAddress" local="address" foreign="id" cardinality="one"
+        <composite alias="Address" class="msOrderAddress" local="id" foreign="order_id" cardinality="one"
                    owner="foreign"/>
         <composite alias="Products" class="msOrderProduct" local="id" foreign="order_id" cardinality="many"
                 owner="local"/>
@@ -340,6 +338,7 @@
 
 
     <object class="msOrderAddress" table="ms2_order_addresses" extends="xPDOSimpleObject">
+        <field key="order_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false"/>
         <field key="user_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false"/>
         <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
         <field key="updatedon" dbtype="datetime" phptype="datetime" null="true" />
@@ -360,10 +359,14 @@
         <field key="text_address" dbtype="text" phptype="string" null="true"/>
         <field key="properties" dbtype="text" phptype="json" null="true"/>
 
+        <index alias="order_id" name="order_id" primary="false" unique="false" type="BTREE">
+            <column key="order_id" length="" collation="A" null="false"/>
+        </index>
         <index alias="user_id" name="user_id" primary="false" unique="false" type="BTREE">
             <column key="user_id" length="" collation="A" null="false"/>
         </index>
 
+        <aggregate alias="Order" class="msOrder" local="order_id" foreign="id" owner="foreign" cardinality="one"/>
         <aggregate alias="User" class="modUser" local="user_id" foreign="id" owner="foreign" cardinality="one"/>
         <aggregate alias="UserProfile" class="modUserProfile" local="user_id" foreign="internalKey" owner="foreign"
                 cardinality="one"/>


### PR DESCRIPTION
### Что оно делает?

Изменил связь между объектом msOrder и объектом msOrderAddress

### Зачем это нужно?

Теперь msOrderAddress подчиняется объекту msOrder и дополняет его как modProfile  дополняет modUser
При удалении заказа удаляется и адрес. 

### Связанные проблема(ы)/PR(ы)

#700
