### PR TITLE
Добавляем в tpl кастомные параметры из вызова

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -210,7 +210,7 @@ if (!empty($rows) && is_array($rows)) {
     if (isset($this) && $this instanceof modSnippet && $this->get('properties')) {
         $properties = $this->get('properties');
     }
-    elseif ($snippet = $modx->getObject('modSnippet', ['name' => 'pdoResources'])) {
+    elseif ($snippet = $modx->getObject('modSnippet', ['name' => 'msProduct'])) {
         $properties = $snippet->get('properties');
     }
     if (!empty($properties)) {

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -204,6 +204,24 @@ if (!empty($rows) && is_array($rows)) {
     }
     $pdoFetch->addTime('Checked the active modifiers');
 
+    // Adding extra parameters into special place so we can put them in a results
+    /** @var modSnippet $snippet */
+    $addplace = $tmprops = [];
+    if (isset($this) && $this instanceof modSnippet && $this->get('properties')) {
+        $tmprops = $this->get('properties');
+    }
+    elseif ($snippet = $modx->getObject('modSnippet', ['name' => 'msProduct'])) {
+        $tmprops = $snippet->get('properties');
+    }
+    if (!empty($tmprops)) {
+        foreach ($scriptProperties as $k => $v) {
+            if (!isset($tmprops[$k])) {
+                $addplace[$k] = $v;
+            }
+        }
+    }
+    
+    
     $opt_time = 0;
     foreach ($rows as $k => $row) {
         if ($modifications) {
@@ -224,7 +242,7 @@ if (!empty($rows) && is_array($rows)) {
 
         $opt_time_start = microtime(true);
         $options = $modx->call('msProductData', 'loadOptions', array($modx, $row['id']));
-        $row = array_merge($row, $options);
+        $row = array_merge($row, $options,$addplace);
         $opt_time += microtime(true) - $opt_time_start;
 
         $tpl = $pdoFetch->defineChunk($row);

--- a/core/components/minishop2/elements/snippets/snippet.ms_products.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_products.php
@@ -206,17 +206,17 @@ if (!empty($rows) && is_array($rows)) {
 
     // Adding extra parameters into special place so we can put them in a results
     /** @var modSnippet $snippet */
-    $addplace = $tmprops = [];
+    $additionalPlaceholders = $properties = [];
     if (isset($this) && $this instanceof modSnippet && $this->get('properties')) {
-        $tmprops = $this->get('properties');
+        $properties = $this->get('properties');
     }
-    elseif ($snippet = $modx->getObject('modSnippet', ['name' => 'msProduct'])) {
-        $tmprops = $snippet->get('properties');
+    elseif ($snippet = $modx->getObject('modSnippet', ['name' => 'pdoResources'])) {
+        $properties = $snippet->get('properties');
     }
-    if (!empty($tmprops)) {
+    if (!empty($properties)) {
         foreach ($scriptProperties as $k => $v) {
-            if (!isset($tmprops[$k])) {
-                $addplace[$k] = $v;
+            if (!isset($properties[$k])) {
+                $additionalPlaceholders[$k] = $v;
             }
         }
     }
@@ -242,7 +242,7 @@ if (!empty($rows) && is_array($rows)) {
 
         $opt_time_start = microtime(true);
         $options = $modx->call('msProductData', 'loadOptions', array($modx, $row['id']));
-        $row = array_merge($row, $options,$addplace);
+        $row = array_merge($additionalPlaceholders, $row, $options);
         $opt_time += microtime(true) - $opt_time_start;
 
         $tpl = $pdoFetch->defineChunk($row);
@@ -275,10 +275,7 @@ if (is_string($rows)) {
     $output = implode($outputSeparator, $output);
 
     if (!empty($tplWrapper) && (!empty($wrapIfEmpty) || !empty($output))) {
-        $output = $pdoFetch->getChunk($tplWrapper, array(
-            'output' => $output,
-            'scriptProperties' => $scriptProperties
-        ));
+        $output = $pdoFetch->getChunk($tplWrapper, array_merge($additionalPlaceholders, ['output' => $output, 'scriptProperties' => $scriptProperties]));
     }
 
     if (!empty($toPlaceholder)) {


### PR DESCRIPTION
### Что оно делает?
Добавляем в tpl кастомные параметры из вызова сниппета, чтобы ими пользоваться в самой tpl-ке вывода.
Уже есть все свойства к wrapp обертке вывода, но это далеко не удобно.

в msProduct, Добавление свойств, как это сделано в pdoResources Если считаете что нужно по-другому - поправьте, но думаю было бы хорошо, чтобы логика поведения была одинакова как в pdoToolse сниппетах так и msProduct.

### Связанные проблема(ы)/PR(ы)
Дополнение к
#711 
