### PR TITLE
Добавлено предупреждение об установке мажорной версии

### DIFF
--- a/_build/setup.options.php
+++ b/_build/setup.options.php
@@ -3,14 +3,19 @@
 /** @var modX $modx */
 $exists = $chunks = false;
 $output = null;
+$showDanger = false;
 /** @var array $options */
 switch ($options[xPDOTransport::PACKAGE_ACTION]) {
     case xPDOTransport::ACTION_INSTALL:
-        $exists = $modx->getObject('transport.modTransportPackage', array('package_name' => 'pdoTools'));
+        $exists = $modx->getObject('transport.modTransportPackage', ['package_name' => 'pdoTools']);
         break;
 
     case xPDOTransport::ACTION_UPGRADE:
-        $exists = $modx->getObject('transport.modTransportPackage', array('package_name' => 'pdoTools'));
+        $exists = $modx->getObject('transport.modTransportPackage', ['package_name' => 'pdoTools']);
+        $miniShop2 = $this->modx->getService('miniShop2');
+        if ($miniShop2->version < '4.0.0') {
+            $showDanger = true;
+        }
 
         if (!empty($options['attributes']['chunks'])) {
             $chunks = '<ul id="formCheckboxes" style="height:200px;overflow:auto;">';
@@ -31,13 +36,23 @@ switch ($options[xPDOTransport::PACKAGE_ACTION]) {
 }
 
 $output = '';
+if ($showDanger) {
+    $output = "
+    <div style='background-color: #f8d7da; border-color:#f5c2c7; color: #842029;  padding:10px; border-radius:5px; margin-bottom: 10px;'>
+    <h3>Внимание!</h3>
+    <p> Установка текущей версии компонента <strong>{$options['signature']}</strong> может сломать Ваш сайт.</p>
+    <p><strong>Пожалуйста, сделайте резервную копию перед установкой!</strong></p>
+    </div>
+";
+}
+
 if (!$exists) {
     switch ($modx->getOption('manager_language')) {
         case 'ru':
-            $output = 'Этот компонент требует <b>pdoTools</b> для быстрой работы сниппетов.<br/>Он будет автоматически скачан и установлен.';
+            $output .= 'Этот компонент требует <b>pdoTools</b> для быстрой работы сниппетов.<br/>Он будет автоматически скачан и установлен.';
             break;
         default:
-            $output = 'This component requires <b>pdoTools</b> for fast work of snippets.<br/><br/>It will be automatically downloaded and installed?';
+            $output .= 'This component requires <b>pdoTools</b> for fast work of snippets.<br/>It will be automatically downloaded and installed?';
     }
 }
 


### PR DESCRIPTION
### Что оно делает?

При обновлении miniShop2 < 4.0.0 на мажорную версию 4  показывается плашка с предупреждением о потенциальных проблемах
