### PR TITLE
Добавление настройки для изменения кол-ва символов в форме заказа у поля телефон.

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -246,6 +246,11 @@ $tmp = [
         'xtype' => 'textfield',
         'area' => 'ms2_order',
     ],
+    'ms2_ordform_phone_length' => [
+        'value' => 16,
+        'xtype' => 'numberfield',
+        'area' => 'ms2_order',
+    ],
 
     'ms2_frontend_css' => [
         'value' => '[[+cssUrl]]web/default.css',

--- a/core/components/minishop2/handlers/msorderhandler.class.php
+++ b/core/components/minishop2/handlers/msorderhandler.class.php
@@ -139,7 +139,8 @@ class msOrderHandler implements msOrderInterface
                 }
                 break;
             case 'phone':
-                $value = substr(preg_replace('/[^-+()0-9]/u', '', $value), 0, 16);
+                $length = $this->modx->getOption('ms2_ordform_phone_length', null, 16);
+                $value = substr(preg_replace('/[^-+()0-9]/u', '', $value), 0, $length);
                 break;
             case 'delivery':
                 /** @var msDelivery $delivery */

--- a/core/components/minishop2/lexicon/en/setting.inc.php
+++ b/core/components/minishop2/lexicon/en/setting.inc.php
@@ -100,6 +100,9 @@ $_lang['setting_ms2_order_handler_class'] = 'Order handler class';
 $_lang['setting_ms2_order_handler_class_desc'] = 'The name of the class that implements the logic of an ordering.';
 $_lang['setting_ms2_order_user_groups'] = 'Groups for registering customers';
 $_lang['setting_ms2_order_user_groups_desc'] = 'Comma-separated list of user groups for adding new users when they orders.';
+$_lang['setting_ms2_ordform_phone_length'] = 'The length of the phone field in the order';
+$_lang['setting_ms2_ordform_phone_length_desc'] = 'When validating the phone field. The maximum length of the phone field in the order form. Characters exceeding this value are deleted.';
+
 $_lang['setting_ms2_email_manager'] = 'Managers mailboxes';
 $_lang['setting_ms2_email_manager_desc'] = 'Comma-separated list of mailboxes of managers, for sending notifications about changes of the status of the order';
 $_lang['setting_ms2_date_format'] = 'Format of dates';

--- a/core/components/minishop2/lexicon/ru/setting.inc.php
+++ b/core/components/minishop2/lexicon/ru/setting.inc.php
@@ -146,6 +146,8 @@ $_lang['setting_ms2_order_product_fields'] = 'Поля таблицы покуп
 $_lang['setting_ms2_order_product_fields_desc'] = 'Список полей таблицы заказанных товаров. Доступны: "count,price,weight,cost,options". Поля товара указываются с префиксом "product_", например "product_pagetitle,product_article". Дополнительно можно указывать значения из поля options с префиксом "option_", например: "option_color,option_size".';
 $_lang['setting_ms2_order_product_options'] = 'Поля опций продукта в заказе';
 $_lang['setting_ms2_order_product_options_desc'] = 'Перечень редактируемых опций товара в окне заказа. По умолчанию color, size';
+$_lang['setting_ms2_ordform_phone_length'] = 'Длинна поля телефон в заказе';
+$_lang['setting_ms2_ordform_phone_length_desc'] = 'При валидации поля phone. Максимальная длинна поля телефон в форме заказа. Превышающее это значение символы удаляются.';
 
 $_lang['ms2_source_thumbnails_desc'] = 'Закодированный в JSON массив с параметрами генерации уменьшенных копий изображений.';
 $_lang['ms2_source_maxUploadWidth_desc'] = 'Максимальная ширина изображения для загрузки. Всё, что больше, будет ужато до этого значения.';


### PR DESCRIPTION
### Что оно делает?

Добавление настройки для изменения кол-ва символов в форме заказа у поля телефон.


### Зачем это нужно?

Бывают длинные номера телефонов и частенько вырезается последние 1...3 символа. Что очень печалит пользователей.

Поэтому предлагаю дать возможность не залазя в код минишопа менять эту настройку в админке.

### Связанные проблема(ы)/PR(ы)

В закрытом PR была просьба:
https://github.com/modx-pro/miniShop2/pull/563#issuecomment-880912361
Да, и пригодится всем тк частенько всплывает этот вопрос.
