### PR TITLE
Убираем ограничение длинны поля телефон в форме заказа.

### DIFF
--- a/core/components/minishop2/handlers/msorderhandler.class.php
+++ b/core/components/minishop2/handlers/msorderhandler.class.php
@@ -139,7 +139,7 @@ class msOrderHandler implements msOrderInterface
                 }
                 break;
             case 'phone':
-                $value = substr(preg_replace('/[^-+()0-9]/u', '', $value), 0, 16);
+                $value = preg_replace('/[^-+()0-9]/u', '', $value);
                 break;
             case 'delivery':
                 /** @var msDelivery $delivery */


### PR DESCRIPTION
### Что оно делает?

Убираем ограничение длинны поля телефон в форме заказа.

### Зачем это нужно?

Если телефон длинный - обрезается номер телефона и менеджеры не могут дозвониться до клиента.
Так же было принято решение убрать ограничение после небольшого обсуждения.

### Связанные проблема(ы)/PR(ы)

https://github.com/modx-pro/miniShop2/pull/563#issuecomment-880912361

