### PR TITLE
Добавил доступные поля в описание настроек

### DIFF
--- a/core/components/minishop2/lexicon/be/setting.inc.php
+++ b/core/components/minishop2/lexicon/be/setting.inc.php
@@ -24,11 +24,11 @@ $_lang['setting_ms2_chunks_categories'] = 'Катэгорыі для спісу 
 $_lang['setting_ms2_chunks_categories_desc'] = 'Спіс ID катэгорый праз коску для спісу чанкив.';
 
 $_lang['setting_ms2_category_grid_fields'] = 'Паля табліцы тавараў';
-$_lang['setting_ms2_category_grid_fields_desc'] = 'Спіс бачных палёў табліцы з таварамі катэгорыі, праз коску.';
+$_lang['setting_ms2_category_grid_fields_desc'] = 'Спіс бачных палёў табліцы з таварамі катэгорыі, праз коску. Даступныя: "id,menuindex,pagetitle,article,price,thumb,new,favorite,popular".';
 $_lang['setting_ms2_product_main_fields'] = 'Асноўныя паля панэлі тавару';
 $_lang['setting_ms2_product_main_fields_desc'] = 'Спіс палёў панэлі тавару, праз коску. Напрыклад: "pagetitle,longtitle,content".';
 $_lang['setting_ms2_product_extra_fields'] = 'Дадатковыя паля тавару';
-$_lang['setting_ms2_product_extra_fields_desc'] = 'Спіс дадатковых палёў тавару, якія выкарыстоўваюцца ў краме, праз коску. Напрыклад: "price,old_price,weight".';
+$_lang['setting_ms2_product_extra_fields_desc'] = 'Спіс дадатковых палёў тавару, якія выкарыстоўваюцца ў краме, праз коску. Даступныя: "price,old_price,article,weight,color,size,vendor,made_in,tags,new,popular,favorite".';
 
 $_lang['setting_mgr_tree_icon_mscategory'] = 'Абразок катэгорыі';
 $_lang['setting_mgr_tree_icon_mscategory_desc'] = 'Абразок катэгорыі тавараў miniShop2 ў дрэве рэсурсаў';
@@ -114,11 +114,13 @@ $_lang['setting_ms2_frontend_js'] = 'Скрыпты франтэнда';
 $_lang['setting_ms2_frontend_js_desc'] = 'Шлях да файла са скрыптамі крамы. Калі вы хочаце выкарыстоўваць уласныя скрыпты — пазначце шлях да іх тут, або ачысціце параметр і загрузіце іх уручную праз шаблон сайта.';
 
 $_lang['setting_ms2_order_grid_fields'] = 'Палі табліцы заказаў';
-$_lang['setting_ms2_order_grid_fields_desc'] = 'Спіс палёў, якія будуць паказаны ў табліцы заказаў. Даступныя: "createdon,updatedon,num,cost,cart_cost,delivery_cost,weight,status,delivery,payment,customer,receiver".';
+$_lang['setting_ms2_order_grid_fields_desc'] = 'Спіс палёў, якія будуць паказаны ў табліцы заказаў. Даступныя: "id,num,customer,status,cost,weight,delivery,payment,createdon,updatedon,comment".';
 $_lang['setting_ms2_order_address_fields'] = 'Палі адрасу дастаўкі';
-$_lang['setting_ms2_order_address_fields_desc'] = 'Спіс палёў дастаўкі, якія будуць паказаны на трэцяй ўкладцы карткі замовы. Даступныя: "receiver,phone,index,country,region,metro,building,city,street,room". Калі параметр пусты, ўкладка будзе схаваная.';
+$_lang['setting_ms2_order_address_fields_desc'] = 'Спіс палёў дастаўкі, якія будуць паказаны на трэцяй ўкладцы карткі замовы. Даступныя: "receiver,phone,email,index,country,region,city,metro,street,building,entrance,floor,room,comment,text_address". Калі параметр пусты, ўкладка будзе схаваная.';
 $_lang['setting_ms2_order_product_fields'] = 'Палі табліцы пакупак';
-$_lang['setting_ms2_order_product_fields_desc'] = 'Спіс палёў табліцы замоўленых тавараў. Даступныя: "count,price,weight,cost,options". Палі тавару паказваюцца з прэфіксам "product_", напрыклад "product_pagetitle,product_article". Дадаткова можна паказваць значэння з поля options з прэфіксам "option_", напрыклад: "option_color,option_size".';
+$_lang['setting_ms2_order_product_fields_desc'] = 'Спіс палёў табліцы замоўленых тавараў. Даступныя: "product_pagetitle,vendor_name,product_article,weight,price,count,cost". Палі тавару паказваюцца з прэфіксам "product_", напрыклад "product_pagetitle,product_article". Дадаткова можна паказваць значэння з поля options з прэфіксам "option_", напрыклад: "option_color,option_size".';
+$_lang['setting_ms2_order_product_options'] = 'Палі опцый прадукта ў замове';
+$_lang['setting_ms2_order_product_options_desc'] = 'Пералік рэдагуемых опцый тавара ў акне замовы. Па змаўчанні: "color,size".';
 
 $_lang['ms2_source_thumbnails_desc'] = 'Закадаваны ў JSON масіў з параметрамі генерацыі паменшаных копій малюнкаў.';
 $_lang['ms2_source_maxUploadWidth_desc'] = 'Максімальная шырыня малюнку для загрузкі. Усё, што больш, будзе сціснута да гэтага значэння.';

--- a/core/components/minishop2/lexicon/en/setting.inc.php
+++ b/core/components/minishop2/lexicon/en/setting.inc.php
@@ -29,11 +29,11 @@ To store the shopping cart and temporary order fields in the session, specify<st
 To store in the database specify <strong>db</strong>";
 
 $_lang['setting_ms2_category_grid_fields'] = 'Fields of the table with goods';
-$_lang['setting_ms2_category_grid_fields_desc'] = 'Comma separated list of visible fields in the table of goods in category.';
+$_lang['setting_ms2_category_grid_fields_desc'] = 'Comma separated list of visible fields in the table of goods in category. Available: "id,menuindex,pagetitle,article,price,thumb,new,favorite,popular".';
 $_lang['setting_ms2_product_main_fields'] = 'Main fields of the panel of the product';
 $_lang['setting_ms2_product_main_fields_desc'] = 'Comma separated list of fields in the panel of the product. For example: "pagetitle,longtitle,content".';
 $_lang['setting_ms2_product_extra_fields'] = 'Extra fields of the panel of the product';
-$_lang['setting_ms2_product_extra_fields_desc'] = 'Comma separated list of fields in the panel of the product, that needed in your shop. For example: "price,old_price,weight".';
+$_lang['setting_ms2_product_extra_fields_desc'] = 'Comma separated list of fields in the panel of the product, that needed in your shop. Available: "price,old_price,article,weight,color,size,vendor,made_in,tags,new,popular,favorite".';
 
 $_lang['setting_mgr_tree_icon_mscategory'] = 'The icon of category';
 $_lang['setting_mgr_tree_icon_mscategory_desc'] = 'The icon of category with miniShop2 products';
@@ -139,11 +139,13 @@ $_lang['setting_ms2_register_frontend_desc'] = "Allow to add js & css files for 
 
 
 $_lang['setting_ms2_order_grid_fields'] = 'Fields of the orders table';
-$_lang['setting_ms2_order_grid_fields_desc'] = 'Comma separated list of fields in the table of orders. Available: "createdon,updatedon,num,cost,cart_cost,delivery_cost,weight,status,delivery,payment,customer,receiver".';
+$_lang['setting_ms2_order_grid_fields_desc'] = 'Comma separated list of fields in the table of orders. Available: "id,num,customer,status,cost,weight,delivery,payment,createdon,updatedon,comment".';
 $_lang['setting_ms2_order_address_fields'] = 'Fields of order address';
-$_lang['setting_ms2_order_address_fields_desc'] = 'Comma separated list of address of order, which will be shown on the third tab. Available: "receiver,phone,index,country,region,metro,building,city,street,room,entrance,floor,text_address". If empty, this tab will be hidden.';
+$_lang['setting_ms2_order_address_fields_desc'] = 'Comma separated list of address of order, which will be shown on the third tab. Available:  "receiver,phone,email,index,country,region,city,metro,street,building,entrance,floor,room,comment,text_address". If empty, this tab will be hidden.';
 $_lang['setting_ms2_order_product_fields'] = 'Field of the purchased products';
-$_lang['setting_ms2_order_product_fields_desc'] = 'which will be shown list of ordered products. Available: "count,price,weight,cost,options". Product fields specified with the prefix "product_", for example "product_pagetitle,product_article". Additionaly, you can specify a values from the options field with the prefix "option_", for example: "option_color,option_size".';
+$_lang['setting_ms2_order_product_fields_desc'] = 'Which will be shown list of ordered products. Available: "product_pagetitle,vendor_name,product_article,weight,price,count,cost". Product fields specified with the prefix "product_", for example "product_pagetitle,product_article". Additionaly, you can specify a values from the options field with the prefix "option_", for example: "option_color,option_size".';
+$_lang['setting_ms2_order_product_options'] = 'Product option fields in an order';
+$_lang['setting_ms2_order_product_options_desc'] = 'Comma separated list of product  option fields in the order window. By default: "color,size".';
 
 $_lang['ms2_source_thumbnails_desc'] = 'JSON encoded array of options for generating thumbnails.';
 $_lang['ms2_source_maxUploadWidth_desc'] = 'Maximum width of image for upload. All images, that exceeds this parameter, will be resized to fit..';

--- a/core/components/minishop2/lexicon/ru/setting.inc.php
+++ b/core/components/minishop2/lexicon/ru/setting.inc.php
@@ -28,11 +28,11 @@ $_lang['setting_ms2_tmp_storage_desc'] = "Для хранения корзины
 Для хранения в базе данных укажите <strong>db</strong>";
 
 $_lang['setting_ms2_category_grid_fields'] = 'Поля таблицы товаров';
-$_lang['setting_ms2_category_grid_fields_desc'] = 'Список видимых полей таблицы с товарами категории, через запятую.';
+$_lang['setting_ms2_category_grid_fields_desc'] = 'Список видимых полей таблицы с товарами категории, через запятую. Доступны: "id,menuindex,pagetitle,article,price,thumb,new,favorite,popular".';
 $_lang['setting_ms2_product_main_fields'] = 'Основные поля панели товара';
 $_lang['setting_ms2_product_main_fields_desc'] = 'Список полей панели товара, через запятую. Например: "pagetitle,longtitle,content".';
 $_lang['setting_ms2_product_extra_fields'] = 'Дополнительные поля товара';
-$_lang['setting_ms2_product_extra_fields_desc'] = 'Список дополнительных полей товара, использующихся в магазине, через запятую. Например: "price,old_price,weight".';
+$_lang['setting_ms2_product_extra_fields_desc'] = 'Список дополнительных полей товара, использующихся в магазине, через запятую. Доступны: "price,old_price,article,weight,color,size,vendor,made_in,tags,new,popular,favorite".';
 
 $_lang['setting_mgr_tree_icon_mscategory'] = 'Иконка категории';
 $_lang['setting_mgr_tree_icon_mscategory_desc'] = 'Иконка категории товаров miniShop2 в дереве ресурсов';
@@ -139,13 +139,13 @@ $_lang['setting_ms2_order_format_num_desc'] = 'Формат нумерации �
 $_lang['setting_ms2_order_format_num_separator'] = 'Разделитель для нумерации заказа';
 $_lang['setting_ms2_order_format_num_separator_desc'] = 'Разделитель для нумерации заказа. Доступные значения: "/", "," и "-"';
 $_lang['setting_ms2_order_grid_fields'] = 'Поля таблицы заказов';
-$_lang['setting_ms2_order_grid_fields_desc'] = 'Список полей, которые будут показаны в таблице заказов. Доступны: "createdon,updatedon,num,cost,cart_cost,delivery_cost,weight,status,delivery,payment,customer,receiver".';
+$_lang['setting_ms2_order_grid_fields_desc'] = 'Список полей, которые будут показаны в таблице заказов. Доступны: "id,num,customer,status,cost,weight,delivery,payment,createdon,updatedon,comment".';
 $_lang['setting_ms2_order_address_fields'] = 'Поля адреса доставки';
-$_lang['setting_ms2_order_address_fields_desc'] = 'Список полей доставки, которые будут показаны на третьей вкладке карточки заказа. Доступны: "receiver,phone,index,country,region,metro,building,city,street,room,entrance,floor,text_address". Если параметр пуст, вкладка будет скрыта.';
+$_lang['setting_ms2_order_address_fields_desc'] = 'Список полей доставки, которые будут показаны на третьей вкладке карточки заказа. Доступны: "receiver,phone,email,index,country,region,city,metro,street,building,entrance,floor,room,comment,text_address". Если параметр пуст, вкладка будет скрыта.';
 $_lang['setting_ms2_order_product_fields'] = 'Поля таблицы покупок';
-$_lang['setting_ms2_order_product_fields_desc'] = 'Список полей таблицы заказанных товаров. Доступны: "count,price,weight,cost,options". Поля товара указываются с префиксом "product_", например "product_pagetitle,product_article". Дополнительно можно указывать значения из поля options с префиксом "option_", например: "option_color,option_size".';
+$_lang['setting_ms2_order_product_fields_desc'] = 'Список полей таблицы заказанных товаров. Доступны: "product_pagetitle,vendor_name,product_article,weight,price,count,cost". Поля товара указываются с префиксом "product_", например "product_pagetitle,product_article". Дополнительно можно указывать значения из поля options с префиксом "option_", например: "option_color,option_size".';
 $_lang['setting_ms2_order_product_options'] = 'Поля опций продукта в заказе';
-$_lang['setting_ms2_order_product_options_desc'] = 'Перечень редактируемых опций товара в окне заказа. По умолчанию color, size';
+$_lang['setting_ms2_order_product_options_desc'] = 'Перечень редактируемых опций товара в окне заказа. По умолчанию: "color,size".';
 
 $_lang['ms2_source_thumbnails_desc'] = 'Закодированный в JSON массив с параметрами генерации уменьшенных копий изображений.';
 $_lang['ms2_source_maxUploadWidth_desc'] = 'Максимальная ширина изображения для загрузки. Всё, что больше, будет ужато до этого значения.';

--- a/core/components/minishop2/lexicon/uk/setting.inc.php
+++ b/core/components/minishop2/lexicon/uk/setting.inc.php
@@ -24,11 +24,11 @@ $_lang['setting_ms2_chunks_categories'] = 'Категорії для списк�
 $_lang['setting_ms2_chunks_categories_desc'] = 'Список ID категорій через кому для списку чанкі.';
 
 $_lang['setting_ms2_category_grid_fields'] = 'Поля таблиці товарів';
-$_lang['setting_ms2_category_grid_fields_desc'] = 'Список видимих полів таблиці з товарами категорії, через кому.';
+$_lang['setting_ms2_category_grid_fields_desc'] = 'Список видимих полів таблиці з товарами категорії, через кому. Доступні: "id,menuindex,pagetitle,article,price,thumb,new,favorite,popular".';
 $_lang['setting_ms2_product_main_fields'] = 'Основні поля панелі товару';
 $_lang['setting_ms2_product_main_fields_desc'] = 'Список полів панелі товару, через кому. Наприклад: "pagetitle,longtitle,content".';
 $_lang['setting_ms2_product_extra_fields'] = 'Додаткові поля товару';
-$_lang['setting_ms2_product_extra_fields_desc'] = 'Список додаткових полів товару, що використовуються в магазині, через кому. Наприклад: "price,old_price,weight".';
+$_lang['setting_ms2_product_extra_fields_desc'] = 'Список додаткових полів товару, що використовуються в магазині, через кому. Доступні: "price,old_price,article,weight,color,size,vendor,made_in,tags,new,popular,favorite".';
 
 $_lang['setting_mgr_tree_icon_mscategory'] = 'Іконка категорії';
 $_lang['setting_mgr_tree_icon_mscategory_desc'] = 'Іконка категорії товарів miniShop2 в дереві ресурсів';
@@ -114,11 +114,13 @@ $_lang['setting_ms2_frontend_js'] = 'Скрипти фронтенду';
 $_lang['setting_ms2_frontend_js_desc'] = 'Шлях до файлу зі скриптами магазину. Якщо ви бажаєте використовувати власні стилі - вкажіть шлях до них тут, або очистіть параметр і завантажте їх вручну через шаблон сайту.';
 
 $_lang['setting_ms2_order_grid_fields'] = 'Поля таблиці замовлень';
-$_lang['setting_ms2_order_grid_fields_desc'] = 'Список полів, що будуть показані в таблиці замовлень. Доступні: "createdon,updatedon,num,cost,cart_cost,delivery_cost,weight,status,delivery,payment,customer,receiver".';
+$_lang['setting_ms2_order_grid_fields_desc'] = 'Список полів, що будуть показані в таблиці замовлень. Доступні: "id,num,customer,status,cost,weight,delivery,payment,createdon,updatedon,comment".';
 $_lang['setting_ms2_order_address_fields'] = 'Поля адреси доставки';
-$_lang['setting_ms2_order_address_fields_desc'] = 'Список полів доставки, що будуть показані на третій вкладці картки замовлення. Доступні: "receiver,phone,index,country,region,metro,building,city,street,room". Якщо параметр пустий, вкладка буде схована.';
+$_lang['setting_ms2_order_address_fields_desc'] = 'Список полів доставки, що будуть показані на третій вкладці картки замовлення. Доступні: "receiver,phone,email,index,country,region,city,metro,street,building,entrance,floor,room,comment,text_address". Якщо параметр пустий, вкладка буде схована.';
 $_lang['setting_ms2_order_product_fields'] = 'Поля таблиці покупок';
-$_lang['setting_ms2_order_product_fields_desc'] = 'Список полів таблиці замовлених товарів. Доступні: "count,price,weight,cost,options". Поля товару вказуються з префіксом "product_", наприклад "product_pagetitle,product_article". Додатково можна вказувати значення з поля options з префіксом "option_", наприклад: "option_color,option_size".';
+$_lang['setting_ms2_order_product_fields_desc'] = 'Список полів таблиці замовлених товарів. Доступні: "product_pagetitle,vendor_name,product_article,weight,price,count,cost". Поля товару вказуються з префіксом "product_", наприклад "product_pagetitle,product_article". Додатково можна вказувати значення з поля options з префіксом "option_", наприклад: "option_color,option_size".';
+$_lang['setting_ms2_order_product_options'] = 'Поля опцій продукту на замовлення';
+$_lang['setting_ms2_order_product_options_desc'] = 'Перелік редагованих опцій товару у вікні замовлення. Типово: "color,size".';
 
 $_lang['ms2_source_thumbnails_desc'] = 'Закодований в JSON масив з параметрами генерації зменшених копій зображень.';
 $_lang['ms2_source_maxUploadWidth_desc'] = 'Максимальна ширина зображення для завантаження. Все,  що більше, буде стиснуто до цього значення.';


### PR DESCRIPTION
### Что оно делает?
- Добавил доступные поля в описание настроек для `en, ru, be, uk`
- Добавил переводы для `setting_ms2_order_product_options`, `setting_ms2_order_product_options_desc` для `en, be, uk`

### Зачем это нужно?
Чтоб было понятно что доступно, если значения сменились

### Связанные проблема(ы)/PR(ы)
https://github.com/modx-pro/miniShop2/issues/593
