### PR TITLE
Поправил комментарии для файлов лексиконов

### DIFF
--- a/core/components/minishop2/lexicon/ru/cart.inc.php
+++ b/core/components/minishop2/lexicon/ru/cart.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Default Russian Lexicon Entries for miniShop2 cart
+ * Cart Lexicon Entries
  *
  * @package minishop2
  * @subpackage lexicon

--- a/core/components/minishop2/lexicon/ru/default.inc.php
+++ b/core/components/minishop2/lexicon/ru/default.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Default Russian Lexicon Entries for miniShop2
+ * Default Lexicon Entries
  *
  * @package minishop2
  * @subpackage lexicon

--- a/core/components/minishop2/lexicon/ru/manager.inc.php
+++ b/core/components/minishop2/lexicon/ru/manager.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manager Russian Lexicon Entries for miniShop2
+ * Manager Lexicon Entries
  *
  * @package minishop2
  * @subpackage lexicon

--- a/core/components/minishop2/lexicon/ru/permissions.inc.php
+++ b/core/components/minishop2/lexicon/ru/permissions.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Permissions Russian Lexicon Entries for miniShop2
+ * Permissions Lexicon Entries
  *
  * @package minishop2
  * @subpackage lexicon

--- a/core/components/minishop2/lexicon/ru/product.inc.php
+++ b/core/components/minishop2/lexicon/ru/product.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
-* Products Russian Lexicon Entries for miniShop2
+* Products Lexicon Entries
 *
 * @package minishop2
 * @subpackage lexicon

--- a/core/components/minishop2/lexicon/ru/properties.inc.php
+++ b/core/components/minishop2/lexicon/ru/properties.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Properties Russian Lexicon Entries for miniShop2
+ * Properties Lexicon Entries
  *
  * @package minishop2
  * @subpackage lexicon

--- a/core/components/minishop2/lexicon/ru/setting.inc.php
+++ b/core/components/minishop2/lexicon/ru/setting.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Settings Russian Lexicon Entries for miniShop2
+ * Settings Lexicon Entries
  *
  * @package minishop2
  * @subpackage lexicon


### PR DESCRIPTION
### Что оно делает?
Поправил комментарии для файлов лексиконов, чтобы при автоматической интеграции с crowdin не было комментариев, типа `Default Russian Lexicon Entries` в файлах других (не russian) языков.