### PR TITLE
возврат дополнительных даннных при манипуляции с корзиной

### DIFF
--- a/core/components/minishop2/handlers/mscarthandler.class.php
+++ b/core/components/minishop2/handlers/mscarthandler.class.php
@@ -160,7 +160,11 @@ class msCartHandler implements msCartInterface
 
         return $this->success(
             'ms2_cart_add_success',
-            $this->status(['key' => $key]),
+            $this->status([
+                'key' => $key,
+                'cart' => $this->cart,
+                'row' => $this->cart[$key]
+            ]),
             ['count' => $count]
         );
     }
@@ -180,6 +184,7 @@ class msCartHandler implements msCartInterface
         if (!$response['success']) {
             return $this->error($response['message']);
         }
+        $row = $this->cart[$key];
         $this->cart = $this->storageHandler->remove($key);
 
         $response = $this->ms2->invokeEvent('msOnRemoveFromCart', ['key' => $key, 'cart' => $this]);
@@ -187,7 +192,13 @@ class msCartHandler implements msCartInterface
             return $this->error($response['message']);
         }
 
-        return $this->success('ms2_cart_remove_success', $this->status());
+        return $this->success(
+            'ms2_cart_remove_success',
+            $this->status([
+                'cart' => $this->cart,
+                'row' => $row
+            ])
+        );
     }
 
     /**
@@ -230,6 +241,8 @@ class msCartHandler implements msCartInterface
         }
         $status['key'] = $key;
         $status['cost'] = $count * $this->cart[$key]['price'];
+        $status['cart'] = $this->cart;
+        $status['row'] = $this->cart[$key];
 
         return $this->success(
             'ms2_cart_change_success',


### PR DESCRIPTION
### Что оно делает?

Добавил в каждый колбэк корзину целиком, а также отдельно ряд  row с которым произошло действие


```
document.addEventListener('DOMContentLoaded', (event) => {
    if (typeof miniShop2 != "undefined") {
        miniShop2.Callbacks.add('Cart.add.response.success', 'cartAddCallbacks', function (response) {
            console.log(response)
        });
        miniShop2.Callbacks.add('Cart.remove.response.success', 'cartRemoveCallbacks', function (response) {
            console.log(response)
        });
        miniShop2.Callbacks.add('Cart.change.response.success', 'cartChangeCallbacks', function (response) {
            console.log(response)
        });
    }
});
```


###  Для чего это нужно?

Для дополнительных манипуляций, связанных с действиями "после".  Перерисовать корзину,  отправить ecommerce событие

