### PR TITLE
Уточнение условия перезаписи old_price в сниппете msCart

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_cart.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_cart.php
@@ -118,7 +118,7 @@ foreach ($cart as $key => $entry) {
     $product['key'] = $key;
     $product['count'] = $entry['count'];
     $old_price = $product['old_price'];
-    if ($product['price'] > $entry['price']) {
+    if ($product['price'] > $entry['price'] && empty($product['old_price'])) {
         $old_price = $product['price'];
     }
     $discount_price = $old_price > 0 ? $old_price - $entry['price'] : 0;


### PR DESCRIPTION
### Что оно делает?
Уточняет условие, при котором для товаров с изначально установленной старой ценой не будет происходить перезаписи old_price

### Зачем это нужно?
Для товаров, у которых изначальное установлена старая цена, не должно происходить перезаписи old_price при различных пересчетах, скдидках и.т.д. Чтобы визуально это не выглядело как уменьшение скидки на товар. Это никак не влияет на расчет конечной стоимости корзины, исключительно на скидку. Такой психологичексий момент для успокоения души покупателей.

![little-fix-old-price2](https://user-images.githubusercontent.com/2706508/216360983-5e8bfbfd-4af5-4937-97e2-2a7cf598cf22.gif)
