### PR TITLE
Небольшая доработка корзины, новые параметры old_cost и total_old_cost

### DIFF
--- a/assets/components/minishop2/js/web/vanilajs/modules/mscart.class.js
+++ b/assets/components/minishop2/js/web/vanilajs/modules/mscart.class.js
@@ -19,8 +19,10 @@ export default class MsCart {
         this.totalWeight = document.querySelectorAll('.ms2_total_weight');
         this.totalCount = document.querySelectorAll('.ms2_total_count');
         this.totalCost = document.querySelectorAll('.ms2_total_cost');
+        this.totalOldCost = document.querySelectorAll('.ms2_total_old_cost');
         this.totalDiscount = document.querySelectorAll('.ms2_total_discount');
         this.cost = '.ms2_cost';
+        this.oldCost = '.ms2_old_cost';
 
         this.eventSubmit = new Event('submit', { bubbles: true, cancelable: true });
 
@@ -77,12 +79,20 @@ export default class MsCart {
         this.totalWeight.forEach(el => { el.innerText = this.minishop.formatWeight(status.total_weight); });
         this.totalCount.forEach(el => { el.innerText = status.total_count; });
         this.totalCost.forEach(el => { el.innerText = this.minishop.formatPrice(status.total_cost); });
+        this.totalOldCost.forEach(el => { el.innerText = this.minishop.formatPrice(status.total_old_cost); });
         this.totalDiscount.forEach(el => { el.innerText = this.minishop.formatPrice(status.total_discount); });
 
         if (typeof status.cost === 'number') {
             const productCost = document.querySelector(`[id="${status.key}"] ${this.cost}`);
             if (productCost) {
                 productCost.innerText = this.minishop.formatPrice(status.cost);
+            }
+        }
+
+        if (typeof status.old_cost === 'number') {
+            const productOldCost = document.querySelector(`[id="${status.key}"] ${this.oldCost}`);
+            if (productOldCost) {
+                productOldCost.innerText = this.minishop.formatPrice(status.old_cost);
             }
         }
 

--- a/core/components/minishop2/elements/snippets/snippet.ms_cart.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_cart.php
@@ -118,7 +118,7 @@ foreach ($cart as $key => $entry) {
     $product['key'] = $key;
     $product['count'] = $entry['count'];
     $old_price = $product['old_price'];
-    if ($product['price'] > $entry['price'] && empty($product['old_price'])) {
+    if ($product['price'] > $entry['price'] && empty((int)$product['old_price'])) {
         $old_price = $product['price'];
     }
     $discount_price = $old_price > 0 ? $old_price - $entry['price'] : 0;

--- a/core/components/minishop2/elements/snippets/snippet.ms_cart.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_cart.php
@@ -108,7 +108,7 @@ foreach ($tmp as $row) {
 
 // Process products in cart
 $products = [];
-$total = ['count' => 0, 'weight' => 0, 'cost' => 0, 'discount' => 0];
+$total = ['count' => 0, 'weight' => 0, 'cost' => 0, 'old_cost' => 0, 'discount' => 0];
 foreach ($cart as $key => $entry) {
     if (!isset($rows[$entry['id']])) {
         continue;
@@ -123,12 +123,13 @@ foreach ($cart as $key => $entry) {
     }
     $discount_price = $old_price > 0 ? $old_price - $entry['price'] : 0;
 
-    $product['old_price'] = $miniShop2->formatPrice($old_price);
     $product['price'] = $miniShop2->formatPrice($entry['price']);
-    $product['weight'] = $miniShop2->formatWeight($entry['weight']);
     $product['cost'] = $miniShop2->formatPrice($entry['count'] * $entry['price']);
+    $product['old_price'] = $miniShop2->formatPrice($old_price);
+    $product['old_cost'] = $miniShop2->formatPrice($entry['count'] * $old_price);
     $product['discount_price'] = $miniShop2->formatPrice($discount_price);
     $product['discount_cost'] = $miniShop2->formatPrice($entry['count'] * $discount_price);
+    $product['weight'] = $miniShop2->formatWeight($entry['weight']);
 
     // Additional properties of product in cart
     if (!empty($entry['options']) && is_array($entry['options'])) {
@@ -148,7 +149,10 @@ foreach ($cart as $key => $entry) {
     $total['weight'] += $entry['count'] * $entry['weight'];
     $total['discount'] += $entry['count'] * $discount_price;
 }
+$total['old_cost'] = $total['cost'] + $total['discount'];
+
 $total['cost'] = $miniShop2->formatPrice($total['cost']);
+$total['old_cost'] = $miniShop2->formatPrice($total['old_cost']);
 $total['discount'] = $miniShop2->formatPrice($total['discount']);
 $total['weight'] = $miniShop2->formatWeight($total['weight']);
 

--- a/core/components/minishop2/elements/snippets/snippet.ms_cart.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_cart.php
@@ -118,7 +118,7 @@ foreach ($cart as $key => $entry) {
     $product['key'] = $key;
     $product['count'] = $entry['count'];
     $old_price = $product['old_price'];
-    if ($product['price'] > $entry['price'] && empty((int)$product['old_price'])) {
+    if ($product['price'] > $entry['price'] && $product['old_price'] == 0) {
         $old_price = $product['price'];
     }
     $discount_price = $old_price > 0 ? $old_price - $entry['price'] : 0;

--- a/core/components/minishop2/handlers/mscarthandler.class.php
+++ b/core/components/minishop2/handlers/mscarthandler.class.php
@@ -241,6 +241,7 @@ class msCartHandler implements msCartInterface
         }
         $status['key'] = $key;
         $status['cost'] = $count * $this->cart[$key]['price'];
+        $status['old_cost'] = $count * $this->cart[$key]['old_price'];
         $status['cart'] = $this->cart;
         $status['row'] = $this->cart[$key];
 
@@ -281,6 +282,7 @@ class msCartHandler implements msCartInterface
         $status = [
             'total_count' => 0,
             'total_cost' => 0,
+            'total_old_cost' => 0,
             'total_weight' => 0,
             'total_discount' => 0,
             'total_positions' => count($this->cart),
@@ -291,6 +293,7 @@ class msCartHandler implements msCartInterface
                 $status['total_cost'] += $item['price'] * $item['count'];
                 $status['total_weight'] += $item['weight'] * $item['count'];
                 $status['total_discount'] += $item['discount_price'] * $item['count'];
+                $status['total_old_cost'] = $status['total_cost'] + $status['total_discount'];
             }
         }
 


### PR DESCRIPTION
### Что оно делает?
Добавил 2 новых параметра в корзину
old_cost - Для товара, в чанке корзины доступен как {$product.old_cost}
total_old_cost - Для суммы корзины без скидки, в чанке корзины доступен как {$total.old_cost}
В чанках ничего не стал менять, чтобы не перегружать верстку избыточной информацией.
В документацию внесу информацию об этих полях и об их использовании, если будет принят PR

Уточнено условие, при котором в сниппете msCart перезаписывается старая цена товара, чтобы визуально это не выглядело как уменьшение скидки.