### PR TITLE
minishop2Config переименован в config в главном классе

### DIFF
--- a/assets/components/minishop2/js/web/vanilajs/modules/minishop.class.js
+++ b/assets/components/minishop2/js/web/vanilajs/modules/minishop.class.js
@@ -1,5 +1,5 @@
 export default class MiniShop {
-  constructor (miniShop2Config) {
+  constructor (config) {
     const defaults = {
       notifyClassPath: './msnotify.class.js',
       notifyClassName: 'MsNotify',
@@ -12,22 +12,22 @@ export default class MiniShop {
       actionUrl: document.location.href,
       formMethod: 'POST',
     }
-    this.miniShop2Config = Object.assign(defaults, miniShop2Config)
+    this.config = Object.assign(defaults, config)
 
-    this.miniShop2Config.callbacksObjectTemplate = this.callbacksObjectTemplate
-    this.Callbacks = this.miniShop2Config.Callbacks = {
+    this.config.callbacksObjectTemplate = this.callbacksObjectTemplate
+    this.Callbacks = this.config.Callbacks = {
       Cart: {
-        add: this.miniShop2Config.callbacksObjectTemplate(),
-        remove: this.miniShop2Config.callbacksObjectTemplate(),
-        change: this.miniShop2Config.callbacksObjectTemplate(),
-        clean: this.miniShop2Config.callbacksObjectTemplate(),
+        add: this.config.callbacksObjectTemplate(),
+        remove: this.config.callbacksObjectTemplate(),
+        change: this.config.callbacksObjectTemplate(),
+        clean: this.config.callbacksObjectTemplate(),
       },
       Order: {
-        add: this.miniShop2Config.callbacksObjectTemplate(),
-        getcost: this.miniShop2Config.callbacksObjectTemplate(),
-        clean: this.miniShop2Config.callbacksObjectTemplate(),
-        submit: this.miniShop2Config.callbacksObjectTemplate(),
-        getrequired: this.miniShop2Config.callbacksObjectTemplate(),
+        add: this.config.callbacksObjectTemplate(),
+        getcost: this.config.callbacksObjectTemplate(),
+        clean: this.config.callbacksObjectTemplate(),
+        submit: this.config.callbacksObjectTemplate(),
+        getrequired: this.config.callbacksObjectTemplate(),
       },
     }
     this.Callbacks.add = this.addCallback.bind(this)
@@ -49,28 +49,28 @@ export default class MiniShop {
 
     if (prefix === 'message') {
       prefix = 'notify'
-      response = await this.sendRequest({ url: this.miniShop2Config.notifySettingsPath, method: 'GET' })
+      response = await this.sendRequest({ url: this.config.notifySettingsPath, method: 'GET' })
       if (response.ok) {
         messageSettings = await response.json()
       }
     }
 
-    const classPath = this.miniShop2Config[prefix + 'ClassPath']
-    const className = this.miniShop2Config[prefix + 'ClassName']
+    const classPath = this.config[prefix + 'ClassPath']
+    const className = this.config[prefix + 'ClassName']
     const config = messageSettings ? messageSettings[className] : this
 
     try {
       const { default: ModuleName } = await import(classPath)
       this[property] = new ModuleName(config)
     } catch (e) {
-      throw new Error(this.miniShop2Config.moduleImportErrorMsg)
+      throw new Error(this.config.moduleImportErrorMsg)
     }
   }
 
   async initialize () {
-    if (!this.miniShop2Config.properties.length) { throw new Error('Не передан массив имён обработчиков') }
+    if (!this.config.properties.length) { throw new Error('Не передан массив имён обработчиков') }
 
-    await this.miniShop2Config.properties.forEach(property => {
+    await this.config.properties.forEach(property => {
       this.setHandler(property)
     })
 
@@ -171,8 +171,8 @@ export default class MiniShop {
   sendRequest (params) {
     const body = params.body || new FormData()
     const headers = params.headers || { 'X-Requested-With': 'XMLHttpRequest' }
-    const url = params.url || this.miniShop2Config.actionUrl
-    const method = params.method || this.miniShop2Config.formMethod
+    const url = params.url || this.config.actionUrl
+    const method = params.method || this.config.formMethod
 
     let options = { method, headers, body }
     if (method === 'GET') {
@@ -191,12 +191,12 @@ export default class MiniShop {
     if (Array.isArray(data)) {
       data.push({
         name: 'ctx',
-        value: this.miniShop2Config.ctx,
+        value: this.config.ctx,
       })
     } else if (data instanceof FormData) {
-      data.append('ctx', this.miniShop2Config.ctx)
+      data.append('ctx', this.config.ctx)
     } else if (typeof data === 'string') {
-      data += '&ctx=' + this.miniShop2Config.ctx
+      data += '&ctx=' + this.config.ctx
     }
 
     const response = await this.sendRequest({ body: data, headers })
@@ -222,10 +222,10 @@ export default class MiniShop {
   }
 
   formatPrice (price) {
-    const pf = this.miniShop2Config.price_format
+    const pf = this.config.price_format
     price = this.numberFormat(price, pf[0], pf[1], pf[2])
 
-    if (this.miniShop2Config.price_format_no_zeros && pf[0] > 0) {
+    if (this.config.price_format_no_zeros && pf[0] > 0) {
       price = price.replace(/(0+)$/, '')
       price = price.replace(/[^0-9]$/, '')
     }
@@ -234,10 +234,10 @@ export default class MiniShop {
   }
 
   formatWeight (weight) {
-    const wf = this.miniShop2Config.weight_format
+    const wf = this.config.weight_format
     weight = this.numberFormat(weight, wf[0], wf[1], wf[2])
 
-    if (this.miniShop2Config.weight_format_no_zeros && wf[0] > 0) {
+    if (this.config.weight_format_no_zeros && wf[0] > 0) {
       weight = weight.replace(/(0+)$/, '')
       weight = weight.replace(/[^0-9]$/, '')
     }

--- a/assets/components/minishop2/js/web/vanilajs/modules/mscart.class.js
+++ b/assets/components/minishop2/js/web/vanilajs/modules/mscart.class.js
@@ -3,13 +3,12 @@ import CustomInputNumber from './custominputnumber.class.js'
 export default class MsCart {
   constructor (minishop) {
     this.minishop = minishop
-    this.config = minishop.miniShop2Config
 
     this.callbacks = {
-      add: this.config.callbacksObjectTemplate(),
-      remove: this.config.callbacksObjectTemplate(),
-      change: this.config.callbacksObjectTemplate(),
-      clean: this.config.callbacksObjectTemplate(),
+      add: this.minishop.config.callbacksObjectTemplate(),
+      remove: this.minishop.config.callbacksObjectTemplate(),
+      change: this.minishop.config.callbacksObjectTemplate(),
+      clean: this.minishop.config.callbacksObjectTemplate(),
     }
 
     this.cart = document.querySelector('#msCart')
@@ -34,7 +33,7 @@ export default class MsCart {
 
     this.cart.querySelectorAll('input[name=count]')?.forEach(el => {
       // eslint-disable-next-line no-new
-      new CustomInputNumber(el, this.config.inputNumber)
+      new CustomInputNumber(el, this.minishop.config.inputNumber)
       el.addEventListener('change', () => el.value && el.closest(this.minishop.form).dispatchEvent(this.eventSubmit))
     })
   }

--- a/assets/components/minishop2/js/web/vanilajs/modules/msorder.class.js
+++ b/assets/components/minishop2/js/web/vanilajs/modules/msorder.class.js
@@ -1,14 +1,13 @@
 export default class MsOrder {
   constructor (minishop) {
     this.minishop = minishop
-    this.config = minishop.miniShop2Config
 
     this.callbacks = {
-      add: this.config.callbacksObjectTemplate(),
-      getcost: this.config.callbacksObjectTemplate(),
-      clean: this.config.callbacksObjectTemplate(),
-      submit: this.config.callbacksObjectTemplate(),
-      getrequired: this.config.callbacksObjectTemplate(),
+      add: this.minishop.config.callbacksObjectTemplate(),
+      getcost: this.minishop.config.callbacksObjectTemplate(),
+      clean: this.minishop.config.callbacksObjectTemplate(),
+      submit: this.minishop.config.callbacksObjectTemplate(),
+      getrequired: this.minishop.config.callbacksObjectTemplate(),
     }
 
     this.order = document.querySelector('#msOrder')


### PR DESCRIPTION
### Что оно делает?

Переименовывает `miniShop2Config` на `config` тем самым добавляя большую абстракцию.

### Зачем это нужно?

Во избежание громоздкости кода, в том числе и для сторонних разработчиков. Т.к. это приводит к сложной ситуации когда:

1. Класс называется `MiniShop`
2. Его экземпляр называется `miniShop2`
3. А конфиг называется `miniShop2Config`

т.е. пред. разработчик предлагает обращаться к конфигу след. образом: `miniShop2.miniShop2Config`