### PR TITLE
4.1.4

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -4,7 +4,7 @@
 const PKG_NAME = 'miniShop2';
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-const PKG_VERSION = '4.1.3';
+const PKG_VERSION = '4.1.4';
 const PKG_RELEASE = 'pl';
 const PKG_AUTO_INSTALL = true;
 

--- a/core/components/minishop2/docs/changelog.txt
+++ b/core/components/minishop2/docs/changelog.txt
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.4-pl] - 2022-03-31
+
+### Added
+ - New lexicons
+ - Ability to attach TV fields to products inside an order letter
+ - Ability to regenerate images from the product grid
+ - Eslint JS Code Validator
+
+ ### Changed
+ - The regular expression for validating a phone number in an order has been moved to the system setting
+ - All JS code in the new set of scripts is formatted according to eslint rules
+ - Minishop2 Config renamed to config in main class of new JS bundle
+
+ ### Fixed
+ -  A bug with missing default value for msOrderAddress.order_id
+ -  A bug with dragging goods in the grid
+
 ## [4.1.3-pl] - 2022-03-14
 
 ### Changed

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -2,7 +2,7 @@
 
 class miniShop2
 {
-    public $version = '4.1.3-pl';
+    public $version = '4.1.4-pl';
     /** @var modX $modx */
     public $modx;
     /** @var pdoFetch $pdoTools */


### PR DESCRIPTION
### Что оно делает?

Добавлено
 - Новые лексиконы
 - Возможность присоединения TV полей к товарам внутри письма о заказе
 - Возможность перегенерации изображений из сетки товаров
 - Валидатор JS кода Eslint

Изменено
- Регулярное выражение для валидации номера телефона в заказе вынесена в системную настройку
- Весь JS код в новом комплекте скриптов отформатирован по правилам eslint
- minishop2Config переименован в config в главном классе нового комлекта JS

Исправлено
- Исправлена ошибка с отсутствующим значением по умолчанию для msOrderAddress.order_id
- Исправлена ошибка перетаскивания товара в гриде
### Зачем это нужно?
