### PR TITLE
fix CustomInputNumber error in cart

### DIFF
--- a/assets/components/minishop2/js/web/vanilajs/modules/custominputnumber.class.js
+++ b/assets/components/minishop2/js/web/vanilajs/modules/custominputnumber.class.js
@@ -2,7 +2,7 @@ export default class CustomInputNumber {
   constructor (element, config) {
     this.field = typeof element === 'string' ? document.querySelector(element) : element
 
-    if (!(this.el instanceof HTMLInputElement)) {
+    if (!(this.field instanceof HTMLInputElement)) {
       throw new Error('Element is undefined.')
     }
 


### PR DESCRIPTION
fix error on cart page
`minishop.class.js:66 Uncaught (in promise) Error: Произошла ошибка при загрузке модуля at MiniShop.setHandler (minishop.class.js:66:13)`