### PR TITLE
4.1.5

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -4,7 +4,7 @@
 const PKG_NAME = 'miniShop2';
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-const PKG_VERSION = '4.1.4';
+const PKG_VERSION = '4.1.5';
 const PKG_RELEASE = 'pl';
 const PKG_AUTO_INSTALL = true;
 

--- a/core/components/minishop2/docs/changelog.txt
+++ b/core/components/minishop2/docs/changelog.txt
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.5-pl] - 2022-04-09
+
+### Fixed
+- Fixed a bug with creating cart key with options
+- fix CustomInputNumber error in cart
+
 ## [4.1.4-pl] - 2022-03-31
 
 ### Added

--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -2,7 +2,7 @@
 
 class miniShop2
 {
-    public $version = '4.1.4-pl';
+    public $version = '4.1.5-pl';
     /** @var modX $modx */
     public $modx;
     /** @var pdoFetch $pdoTools */


### PR DESCRIPTION
### Что оно делает?

Поднял версию до 4.1.5

### Зачем это нужно?
Выпущены фиксы
- Fixed a bug with creating cart key with options
- fix CustomInputNumber error in cart


