### PR TITLE
Добавил события при создании вендора #861

### DIFF
--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -54,6 +54,12 @@ $tmp = [
 
     'msOnManagerCustomCssJs',
 
+    'msOnBeforeVendorCreate',
+    'msOnAfterVendorCreate',
+    'msOnBeforeVendorUpdate',
+    'msOnAfterVendorUpdate',
+    'msOnBeforeVendorDelete',
+    'msOnAfterVendorDelete',
 ];
 
 foreach ($tmp as $k => $v) {

--- a/core/components/minishop2/processors/mgr/settings/vendor/create.class.php
+++ b/core/components/minishop2/processors/mgr/settings/vendor/create.class.php
@@ -7,6 +7,8 @@ class msVendorCreateProcessor extends modObjectCreateProcessor
     public $classKey = 'msVendor';
     public $languageTopics = ['minishop2'];
     public $permission = 'mssetting_save';
+    public $beforeSaveEvent = 'msOnBeforeVendorCreate';
+    public $afterSaveEvent = 'msOnAfterVendorCreate';
 
     /**
      * @return bool|null|string

--- a/core/components/minishop2/processors/mgr/settings/vendor/remove.class.php
+++ b/core/components/minishop2/processors/mgr/settings/vendor/remove.class.php
@@ -7,6 +7,8 @@ class msVendorRemoveProcessor extends modObjectRemoveProcessor
     public $classKey = 'msVendor';
     public $languageTopics = ['minishop2'];
     public $permission = 'mssetting_save';
+    public $beforeRemoveEvent = 'msOnBeforeVendorDelete';
+    public $afterRemoveEvent = 'msOnAfterVendorDelete';
 
     /**
      * @return bool|null|string

--- a/core/components/minishop2/processors/mgr/settings/vendor/update.class.php
+++ b/core/components/minishop2/processors/mgr/settings/vendor/update.class.php
@@ -7,6 +7,8 @@ class msVendorUpdateProcessor extends modObjectUpdateProcessor
     public $classKey = 'msVendor';
     public $languageTopics = ['minishop2'];
     public $permission = 'mssetting_save';
+    public $beforeSaveEvent = 'msOnBeforeVendorUpdate';
+    public $afterSaveEvent = 'msOnAfterVendorUpdate';
 
     /**
      * @return bool|null|string


### PR DESCRIPTION
### Что оно делает?

Добавляем события при удалении и создании, обновлении производителей

```php
'msOnBeforeVendorCreate', => 'mode', 'data', 'object,
'msOnAfterVendorCreate',  => 'mode', 'data', 'object,
'msOnBeforeVendorUpdate',  => 'mode', 'data', 'object,
'msOnAfterVendorUpdate',  => 'mode', 'data', 'object,
'msOnBeforeVendorDelete',  => 'object',
'msOnAfterVendorDelete',  => 'object',
```
### Связанные проблема(ы)/PR(ы)

#861
