### PR TITLE
Принудительное создание поля msVendor.rank

### DIFF
--- a/_build/resolvers/resolve.tables.php
+++ b/_build/resolvers/resolve.tables.php
@@ -123,6 +123,13 @@ if ($transport->xpdo) {
                     $sql = "CREATE INDEX `order_id` ON {$modx->getTableName('msOrderAddress')} (`order_id`)";
                     $modx->exec($sql);
                 }
+
+                if ($miniShop2->version < '4.2.0') {
+                    $sql = "ALTER TABLE {$modx->getTableName('msVendor')} ADD  `rank`  INT (10) UNSIGNED NOT NULL DEFAULT 0";
+                    $modx->exec($sql);
+                    $sql = "ALTER TABLE {$modx->getTableName('msVendor')} ADD INDEX(`rank`)";
+                    $modx->exec($sql);
+                }
             }
 
             break;


### PR DESCRIPTION
### Что оно делает?

Принудительно создаем поле msVendor.rank


### Зачем это нужно?

Костыль для ситуации, при которой обновление таблиц происходит на основании старой схемы из предыдущей версии minishop2, пропуская новые поля.  Таким образом добавляя новые поля в модель, но пропуская их в таблице получаем серверные ошибки типа  fileld not found


