### PR TITLE
Возможность изменения названия класса элемента формы #msOrder, при во…

### DIFF
--- a/assets/components/minishop2/js/web/vanilajs/modules/msorder.class.js
+++ b/assets/components/minishop2/js/web/vanilajs/modules/msorder.class.js
@@ -11,7 +11,7 @@ export default class MsOrder {
     }
 
     this.defaults = {
-      inputErrorClassName: 'error'
+      inputErrorClassName: 'error',
     }
 
     this.config = Object.assign({}, this.defaults, this.minishop.config.Order)

--- a/assets/components/minishop2/js/web/vanilajs/modules/msorder.class.js
+++ b/assets/components/minishop2/js/web/vanilajs/modules/msorder.class.js
@@ -10,9 +10,16 @@ export default class MsOrder {
       getrequired: this.minishop.config.callbacksObjectTemplate(),
     }
 
+    this.defaults = {
+      inputErrorClassName: 'error'
+    }
+
+    this.config = Object.assign({}, this.defaults, this.minishop.config.Order)
+
     this.order = document.querySelector('#msOrder')
     this.deliveryInput = 'input[name="delivery"]'
     this.inputParent = '.input-parent'
+    this.inputErrorClassName = this.config.inputErrorClassName
     this.paymentInput = 'input[name="payment"]'
     this.paymentInputUniquePrefix = '#payment_'
     this.deliveryInputUniquePrefix = '#delivery_'
@@ -112,16 +119,16 @@ export default class MsOrder {
       }
 
       field.value = response.data[key] || ''
-      field.classList.remove('error')
-      field.closest(this.inputParent).classList.remove('error')
+      field.classList.remove(this.inputErrorClassName)
+      field.closest(this.inputParent).classList.remove(this.inputErrorClassName)
     }
 
     this.callbacks.add.response.error = () => {
       const field = this.order.querySelector(`[name="${key}"]`)
       if (['checkbox', 'radio'].includes(field.type)) {
-        field.closest(this.inputParent).classList.add('error')
+        field.closest(this.inputParent).classList.add(this.inputErrorClassName)
       } else {
-        field.classList.add('error')
+        field.classList.add(this.inputErrorClassName)
       }
     }
 
@@ -195,8 +202,8 @@ export default class MsOrder {
 
       if (this.order.elements) {
         Array.from(this.order.elements).forEach(el => {
-          el.classList.remove('error')
-          el.closest(this.inputParent)?.classList.remove('error')
+          el.classList.remove(this.inputErrorClassName)
+          el.closest(this.inputParent)?.classList.remove(this.inputErrorClassName)
         })
       }
 
@@ -206,9 +213,9 @@ export default class MsOrder {
           const field = this.order.querySelector(`[name="${key}"]`)
 
           if (['checkbox', 'radio'].includes(field.type)) {
-            field.closest(this.inputParent).classList.add('error')
+            field.closest(this.inputParent).classList.add(this.inputErrorClassName)
           } else {
-            field.classList.add('error')
+            field.classList.add(this.inputErrorClassName)
           }
         }
       }


### PR DESCRIPTION
…зникновении ошибки ввода.

### Что оно делает?

Дает возможность изменить класс error (ошибка валидации формы #msOrder) на усмотрение разработчика. Возможность стандартизации  разметки шаблона с фреймворком [Bootstap 5](https://getbootstrap.com/docs/5.2/forms/validation/)

### Зачем это нужно?

Возможность использовать стили валидации формы фреймворка Bootstap 4/5. Единый стиль валидации форм на всем сайте, к примеру mvtForms2 использует стандартные стили Bootstap 4/5, miniShop2 свои стили. 

### Как это работает

Необходимо в переменную miniShop2Config записать в JS файле :

```
if (miniShop2Config) {
    miniShop2Config.Order = {
        inputErrorClassName: 'is-invalid'
    }
}
```

Получаем результат. 

![image](https://github.com/modx-pro/miniShop2/assets/20732384/2830c73d-580f-4c10-a388-b9ea12829539)


### Связанные проблема(ы)/PR(ы)

#538 
