### PR TITLE
change method's visibility

### DIFF
--- a/core/components/minishop2/handlers/mscarthandler.class.php
+++ b/core/components/minishop2/handlers/mscarthandler.class.php
@@ -389,7 +389,7 @@ class msCartHandler implements msCartInterface
      * @return string
      *
      */
-    private function getProductKey(array $product, array $options = [])
+    protected function getProductKey(array $product, array $options = [])
     {
         $key_fields = explode(',', $this->config['cart_product_key_fields']);
         $product['options'] = $options;


### PR DESCRIPTION
### Что оно делает?

Изменил область видимости метода с private на protected

### Зачем это нужно?

При создании кастомного класса заказа, методы, которые в нем используются обязаны быть protected или public, для того чтобы быть видимыми из наследника


