### PR TITLE
Добавлен пропущенный rank равный нулю в сниппете msGetOrder

### DIFF
--- a/core/components/minishop2/elements/snippets/snippet.ms_get_order.php
+++ b/core/components/minishop2/elements/snippets/snippet.ms_get_order.php
@@ -85,7 +85,7 @@ if (!empty($includeThumbs)) {
         foreach ($thumbs as $thumb) {
             $leftJoin[$thumb] = [
                 'class' => 'msProductFile',
-                'on' => "`{$thumb}`.product_id = msProduct.id AND `{$thumb}`.parent != 0 AND `{$thumb}`.path LIKE '%/{$thumb}/%'",
+                'on' => "`{$thumb}`.product_id = msProduct.id AND `{$thumb}`.parent != 0 AND `{$thumb}`.path LIKE '%/{$thumb}/%' AND `{$thumb}`.`rank` = 0",
             ];
             $select[$thumb] = "`{$thumb}`.url as '{$thumb}'";
         }


### PR DESCRIPTION
Если у товара более одного изображения, то в результате будет попадать рандомное изображение. Проблема присутствует, если использовать вызов сниппета с параметром includeThumbs.