### PR TITLE
Исправление удаления опций

### DIFF
--- a/core/components/minishop2/model/minishop2/mscategoryoption.class.php
+++ b/core/components/minishop2/model/minishop2/mscategoryoption.class.php
@@ -53,7 +53,7 @@ class msCategoryOption extends xPDOObject
             $products = implode(',', $products);
             $key = $this->getOne('Option')->get('key');
             $key = $this->xpdo->quote($key);
-            if (count($products) > 0) {
+            if ($products !== '') {
                 $sql = "DELETE FROM {$this->xpdo->getTableName('msProductOption')} WHERE `product_id` IN ({$products}) AND `key`={$key};";
                 $stmt = $this->xpdo->prepare($sql);
                 $stmt->execute();


### PR DESCRIPTION
### Что оно делает?

В PHP 8 более строгая проверка типов. Мы больше не можем использовать `string` в `count()`, т.к. она принимает в качестве аргумента только `Countable|array`. В коде же мы записываем в переменную `$products` результат `implode()` (которая всегда возвращает `string`) и передаём это в `count()`, что приводит к ошибке (исключение `TypeError`):
https://github.com/modx-pro/miniShop2/blob/687e2da482497f0aacbfe5e00d64747da69eb21f/core/components/minishop2/model/minishop2/mscategoryoption.class.php#L53-L56
Заменил на проверку пустой строки:
```php
if ($products !== '') {
```

### Зачем это нужно?

Не удаляются ресурсы в корзине. Не удаляются опции у категорий.
В логе сервера при этом ошибки вида:
```
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, string given in .../core/components/minishop2/model/minishop2/mscategoryoption.class.php:<actual line>
```

### Связанные проблема(ы)/PR(ы)

Resolves #671
