### PR TITLE
Исправление пропадания опций у товаров с несколькими категориями

### DIFF
--- a/core/components/minishop2/model/minishop2/msproductdata.class.php
+++ b/core/components/minishop2/model/minishop2/msproductdata.class.php
@@ -233,6 +233,8 @@ class msProductData extends xPDOSimpleObject
             $c->where(['msCategoryOption.category_id:IN' => $categories]);
         }
         $c->groupby('msOption.id');
+        $c->groupby('msCategoryOption.option_id');
+        $c->groupby('msCategoryOption.category_id');
 
         return $c;
     }


### PR DESCRIPTION
### Что оно делает?

Первичный ключ (поля `option_id` и `category_id`) таблицы `ms_category_options`, с которой джойнится таблица `ms_options` в запросе из `msProductData::prepareOptionListCriteria()`, добавлен в `GROUP BY`.

### Зачем это нужно?

Начиная с MySQL 5.7.5 по-умолчанию включён режим `ONLY_FULL_GROUP_BY`. В этом режиме мы не можем в запросе выбирать поля, которые не перечислены в `GROUP BY`, не определены явно в результаты группировки или для которых не применяются функции агрегации.

Проявление проблемы в miniShop2: Если товару задать несколько категорий, то в админке и на сайте не выводятся опции товара. В логе получаем ошибку MySQL:
```
#1055 - Expression #1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'sandbox_print.msCategoryOption.rank' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```
Можно, конечно, отключить `ONLY_FULL_GROUP_BY`, но это уже более костыльный вариант, тем более что у самого modx с этим режимом проблем нет.