### PR TITLE
Позволяет изменить логику поиска id покукпателя при заказе

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -703,6 +703,8 @@ class miniShop2
         ]);
         if (!$response['success']) {
             return $response['message'];
+        } else {
+            $customer = $response['data']['customer'] ?? null;
         }
 
         if (!$customer) {


### PR DESCRIPTION
Добавление возможности изменить покупателя по своей логике на событие msOnBeforeGetOrderCustomer Необходимо иногда убирать стандартный метод определения ID пользователя и заменять на свой. Предложено одно из решений.
