### PR TITLE
add remains and reserved fields to msProductData schema

### DIFF
--- a/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
+++ b/core/components/minishop2/model/schema/minishop2.mysql.schema.xml
@@ -31,6 +31,8 @@
         <field key="price" dbtype="decimal" precision="12,2" phptype="float" null="true" default="0"/>
         <field key="old_price" dbtype="decimal" precision="12,2" phptype="float" null="true" default="0"/>
         <field key="weight" dbtype="decimal" precision="13,3" phptype="float" null="true" default="0"/>
+        <field key="remains" dbtype="int" precision="10" phptype="integer" null="false" default="0"/>
+        <field key="reserved" dbtype="int" precision="10" phptype="integer" null="false" default="0"/>
         <field key="image" dbtype="varchar" precision="255" phptype="string" null="true"/>
         <field key="thumb" dbtype="varchar" precision="255" phptype="string" null="true"/>
         <field key="vendor" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="true"


### PR DESCRIPTION
https://github.com/modx-pro/miniShop2/blob/afa3318293022e583f61826b7eb5a256fe5156b1/assets/components/minishop2/js/mgr/product/product.common.js#L538C2-L542C15
fields already exists in lexicons and js assets, but not in schema
maybe better float than int?