### PR TITLE
add old_status to msOnBeforeChangeStatus and msOnChangeStatus events

### DIFF
--- a/core/components/minishop2/model/minishop2/minishop2.class.php
+++ b/core/components/minishop2/model/minishop2/minishop2.class.php
@@ -843,7 +843,8 @@ class miniShop2
 
         $response = $this->invokeEvent('msOnBeforeChangeOrderStatus', [
             'order' => $order,
-            'status' => $order->get('status'),
+            'old_status' => $old_status->get('id'),
+            'status' => $status_id,
         ]);
         if (!$response['success']) {
             return $response['message'];
@@ -855,6 +856,7 @@ class miniShop2
             $this->orderLog($order->get('id'), 'status', $status_id);
             $response = $this->invokeEvent('msOnChangeOrderStatus', [
                 'order' => $order,
+                'old_status' => $old_status->get('id'),
                 'status' => $status_id,
             ]);
             if (!$response['success']) {


### PR DESCRIPTION
раньше:
- `msOnBeforeChangeOrderStatus`
- `msOnChangeOrderStatus` - смена статуса заказа
  - `order` - объект *msOrder*
  - `status` - идентификатор статуса

при этом в msOnBeforeChangeOrderStatus попадал старый статус, который итак можно узнать из объекта msOrder $order, а новый не узнать, а в msOnChangeOrderStatus - наоборот, новый, а старый не узнать

теперь:
- `msOnChangeOrderStatus` - смена статуса заказа
  - `order` - объект *msOrder*
  - `old_status` - идентификатор старого статуса
  - `status` - идентификатор нового статуса