### PR TITLE
Autofix: miniShop2 плохо удаляются

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -226,6 +226,7 @@ $vehicle->resolve('file', [
     'target' => "return MODX_CORE_PATH . 'components/';",
 ]);
 /** @var array $BUILD_RESOLVERS */
+$BUILD_RESOLVERS[] = 'uninstall';
 foreach ($BUILD_RESOLVERS as $resolver) {
     if ($vehicle->resolve('php', ['source' => $sources['resolvers'] . 'resolve.' . $resolver . '.php'])) {
         $modx->log(modX::LOG_LEVEL_INFO, 'Added resolver "' . $resolver . '" to category.');


### PR DESCRIPTION
Add a new uninstall resolver to the build.transport.php file to handle cleanup during uninstallation. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    